### PR TITLE
Simplify WS subscription in import_realtime_ops

### DIFF
--- a/postgres/import_realtime_ops.py
+++ b/postgres/import_realtime_ops.py
@@ -56,8 +56,7 @@ def on_close(ws):
 
 def on_open(ws):
     def run(*args):
-        ws.send('{"method": "call", "params": [1, "database", []], "id": 3}')
-        ws.send('{"method": "call", "params": [2, "set_subscribe_callback", [5, true]], "id": 6}')
+        ws.send('{"method": "set_subscribe_callback", "params": [5, true], "id": 6}')
 
     thread.start_new_thread(run, ())
 


### PR DESCRIPTION
The Database API is the default one and there's no need to request it before calling it, AFAIK.
This patch removes one unnecessary RPC call and it seems to be working the same way according to my testing.

What do you think @oxarbitrage? Is there any reason why we would request the Database API first?