### PR TITLE
Polish code and introduce Connexion.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,7 @@ WORKDIR /explorer
 # Always make the project virtualenv active
 ENV VIRTUAL_ENV=/home/explorer/env \
 	PATH=/home/explorer/env/bin:$PATH \
-	FLASK_APP=api.py
+	FLASK_APP=app.py
 
 EXPOSE 5000
 

--- a/README.md
+++ b/README.md
@@ -206,6 +206,11 @@ Install python and pip:
 
 `apt-get install -y python python-pip`
 
+Clone the app:
+
+    git clone https://github.com/oxarbitrage/bitshares-python-api-backend
+    cd bitshares-python-api-backend/
+    
 Install virtual environment and setup:
 
     pip install virtualenv 
@@ -224,17 +229,8 @@ Deactivate with:
 
 Install dependencies in virtual env activated:
 
-    pip install flask
-    pip install flask-cors
-    pip install websocket-client
-    pip install psycopg2
-    pip install psycopg2-binary
-    pip install flasgger
+    pip install -r requirements/production.pip
 
-Clone the app:
-
-    git clone https://github.com/oxarbitrage/bitshares-python-api-backend
-    cd bitshares-python-api-backend/
 
 To run the api, always need to have the full path to program in `PYTHONPATH` environment variable exported:
 
@@ -283,7 +279,7 @@ Add the following taks to cron file with `crontab -e`:
 
 In order to simply test and run the backend api you can do:
 
-    export FLASK_APP=wrapper.py
+    export FLASK_APP=app.py
     flask run --host=0.0.0.0
 
 Then go to apidocs with your server external address:
@@ -309,7 +305,7 @@ Create config file in /etc/nginx/sites-available:
         server_name 185.208.208.184;
         location / {
             include uwsgi_params;
-            uwsgi_pass unix:/tmp/api.sock;
+            uwsgi_pass unix:/tmp/app.sock;
         }
     }
 
@@ -320,7 +316,7 @@ Create symbolic link to sites-enabled and restart nginx:
 
 Now api can be started with:
 
-    (wrappers) root@oxarbitrage ~/bitshares/bitshares-python-api-backend # uwsgi --ini api.ini
+    (wrappers) root@oxarbitrage ~/bitshares/bitshares-python-api-backend # uwsgi --ini app.ini
 
 #### Domain setup and SSL
 

--- a/api.py
+++ b/api.py
@@ -362,12 +362,7 @@ def get_workers():
 
 
 def isObject(string):
-    parts = string.split(".")
-    if len(parts) == 3:
-        return True
-    else:
-        return False
-
+    return len(string.split(".")) == 3
 
 @app.route('/get_markets')
 def get_markets():

--- a/api.py
+++ b/api.py
@@ -206,10 +206,10 @@ def account_history():
     account_history = bitshares_ws_client.request('history', 'get_account_history', [account_id, "1.11.1", 20, "1.11.9999999999"])
 
     if(len(account_history) > 0):
-        for c in range(0, len(account_history)):
-            creation_block = bitshares_ws_client.request('database', 'get_block_header', [str(account_history[c]["block_num"]), 0])
-            account_history[c]["timestamp"] = creation_block["timestamp"]
-            account_history[c]["witness"] = creation_block["witness"]
+        for transaction in account_history:
+            creation_block = bitshares_ws_client.request('database', 'get_block_header', [str(transaction["block_num"]), 0])
+            transaction["timestamp"] = creation_block["timestamp"]
+            transaction["witness"] = creation_block["witness"]
     try:
         return jsonify(account_history)
     except:
@@ -497,17 +497,17 @@ def market_chart_data():
     market_history = bitshares_ws_client.request('history', 'get_market_history', [base_id, quote_id, 86400, ago.strftime("%Y-%m-%dT%H:%M:%S"), now.strftime("%Y-%m-%dT%H:%M:%S")])
 
     data = []
-    for w in range(0, len(market_history)):
+    for market_operation in market_history:
 
-        open_quote = float(market_history[w]["open_quote"])
-        high_quote = float(market_history[w]["high_quote"])
-        low_quote = float(market_history[w]["low_quote"])
-        close_quote = float(market_history[w]["close_quote"])
+        open_quote = float(market_operation["open_quote"])
+        high_quote = float(market_operation["high_quote"])
+        low_quote = float(market_operation["low_quote"])
+        close_quote = float(market_operation["close_quote"])
 
-        open_base = float(market_history[w]["open_base"])
-        high_base = float(market_history[w]["high_base"])
-        low_base = float(market_history[w]["low_base"])
-        close_base = float(market_history[w]["close_base"])
+        open_base = float(market_operation["open_base"])
+        high_base = float(market_operation["high_base"])
+        low_base = float(market_operation["low_base"])
+        close_base = float(market_operation["close_base"])
 
         open = 1/(float(open_base/base_precision)/float(open_quote/quote_precision))
         high = 1/(float(high_base/base_precision)/float(high_quote/quote_precision))
@@ -562,11 +562,11 @@ def top_proxies():
 
     proxies = []
 
-    for p in range(0, len(results)):
+    for reffered_account in results:
 
         proxy_line = [0] * 5
 
-        proxy_id = results[p][0]
+        proxy_id = reffered_account[0]
         proxy_line[0] = proxy_id
 
         query = "SELECT account_name, amount FROM holders WHERE account_id=%s LIMIT 1"
@@ -589,9 +589,9 @@ def top_proxies():
 
         proxy_line[2] = int(proxy_amount)
 
-        for p2 in range(0, len(results2)):
-            amount = results2[p2][0]
-            account_id = results2[p2][1]
+        for account_with_proxy in results2:
+            amount = account_with_proxy[0]
+            account_id = account_with_proxy[1]
             proxy_line[2] = proxy_line[2] + int(amount)  # total proxy votes
             proxy_line[3] = proxy_line[3] + 1       # followers
 
@@ -778,8 +778,8 @@ def top_markets():
     cur.execute(query)
     results = cur.fetchall()
     total = 0
-    for v in range(0, len(results)):
-        total = total + results[v][0]
+    for v in results:
+        total = total + v[0]
 
     query = "SELECT pair, volume FROM markets ORDER BY volume DESC LIMIT 7"
     cur.execute(query)
@@ -808,8 +808,8 @@ def top_smartcoins():
     cur.execute(query)
     results = cur.fetchall()
     total = 0
-    for v in range(0, len(results)):
-        total = total + results[v][0]
+    for v in results:
+        total = total + v[0]
 
     query = "SELECT aname, volume FROM assets WHERE type='SmartCoin' ORDER BY volume DESC LIMIT 7"
     cur.execute(query)
@@ -838,8 +838,8 @@ def top_uias():
     cur.execute(query)
     results = cur.fetchall()
     total = 0
-    for v in range(0, len(results)):
-        total = total + results[v][0]
+    for v in results:
+        total = total + v[0]
 
     query = "SELECT aname, volume FROM assets WHERE TYPE='User Issued' ORDER BY volume DESC LIMIT 7"
     cur.execute(query)
@@ -953,10 +953,10 @@ def account_history_pager():
 
     if start > 0:
         account_history = bitshares_ws_full_client.request('history', 'get_relative_account_history', [account_id, stop, 20, start])
-        for c in range(0, len(account_history)):
-            block_header = bitshares_ws_full_client.request('database', 'get_block_header', [account_history[c]["block_num"], 0])
-            account_history[c]["timestamp"] = block_header["timestamp"]
-            account_history[c]["witness"] = block_header["witness"]
+        for transaction in account_history:
+            block_header = bitshares_ws_full_client.request('database', 'get_block_header', [transaction["block_num"], 0])
+            transaction["timestamp"] = block_header["timestamp"]
+            transaction["witness"] = block_header["witness"]
 
         return jsonify(account_history)
     else:
@@ -1091,8 +1091,7 @@ def get_all_asset_holders():
 
     asset_holders = bitshares_ws_client.request('asset', 'get_asset_holders', [asset_id, 0, 100])
 
-    for r in range(0, len(asset_holders)):
-        all.append(asset_holders[r])
+    all.extend(asset_holders)
 
     len_result = len(asset_holders)
     start = 100
@@ -1100,9 +1099,7 @@ def get_all_asset_holders():
         start = start + 100
         asset_holders = bitshares_ws_client.request('asset', 'get_asset_holders', [asset_id, start, 100])
         len_result = len(asset_holders)
-        for r in range(0, len(asset_holders)):
-            all.append(asset_holders[r])
-
+        all.extend(asset_holders)
 
     return jsonify(all)
 

--- a/api.yaml
+++ b/api.yaml
@@ -12,7 +12,7 @@ paths:
   "/header":
     get:
       description: Get some blockchain information.
-      operationId: header
+      operationId: api.explorer.header
       responses:
         '200':
           description: Array of operation data
@@ -24,7 +24,7 @@ paths:
   "/account":
     get:
       description: Get an account object.
-      operationId: account
+      operationId: api.explorer.account
       parameters:
         - in: query
           name: account_id
@@ -43,7 +43,7 @@ paths:
   "/account_name":
     get:
       description: Get account name by ID
-      operationId: account_name
+      operationId: api.explorer.account_name
       parameters:
         - in: query
           name: account_id
@@ -62,7 +62,7 @@ paths:
   "/account_id":
     get:
       description: Get account ID by name
-      operationId: account_id
+      operationId: api.explorer.account_id
       parameters:
         - in: query
           name: account_name
@@ -81,7 +81,7 @@ paths:
   "/operation":
     get:
       description: Get operation by ID
-      operationId: operation
+      operationId: api.explorer.get_operation
       parameters:
         - in: query
           name: operation_id
@@ -100,7 +100,7 @@ paths:
   "/operation_full":
     get:
       description: Get operation by ID in a full node connection
-      operationId: operation_full
+      operationId: api.explorer.operation_full
       parameters:
         - in: query
           name: operation_id
@@ -119,7 +119,7 @@ paths:
   "/operation_full_elastic":
     get:
       description: Get operation by ID in a elasticsearch wrapper connection
-      operationId: operation_full_elastic
+      operationId: api.explorer.operation_full_elastic
       parameters:
         - in: query
           name: operation_id
@@ -138,7 +138,7 @@ paths:
   "/accounts":
     get:
       description: Get an account list of the most 100 rich CORE holders.
-      operationId: accounts
+      operationId: api.explorer.accounts
       responses:
         '200':
           description: Rich list of accounts
@@ -150,7 +150,7 @@ paths:
   "/full_account":
     get:
       description: Given an account ID, the call will return full account data.
-      operationId: full_account
+      operationId: api.explorer.full_account
       parameters:
         - in: query
           name: account_id
@@ -169,7 +169,7 @@ paths:
   "/assets":
     get:
       description: Get list of assets that had volume in the last 24 hours.
-      operationId: assets
+      operationId: api.explorer.assets
       responses:
         '200':
           description: List of assets with 24hs volume
@@ -181,7 +181,7 @@ paths:
   "/fees":
     get:
       description: Get network fee data.
-      operationId: fees
+      operationId: api.explorer.fees
       responses:
         '200':
           description: Fee data
@@ -193,7 +193,7 @@ paths:
   "/account_history":
     get:
       description: Get the last 20 operations of an account
-      operationId: account_history
+      operationId: api.explorer.account_history
       parameters:
         - in: query
           name: account_id
@@ -212,7 +212,7 @@ paths:
   "/get_asset":
     get:
       description: Get all info about an asset
-      operationId: get_asset
+      operationId: api.explorer.get_asset
       parameters:
         - in: query
           name: asset_id
@@ -231,7 +231,7 @@ paths:
   "/get_asset_and_volume":
     get:
       description: Same as get_asset but with additional volume info.
-      operationId: get_asset_and_volume
+      operationId: api.explorer.get_asset_and_volume
       parameters:
         - in: query
           name: asset_id
@@ -250,7 +250,7 @@ paths:
   "/block_header":
     get:
       description: Get the block header information of a block_num
-      operationId: block_header
+      operationId: api.explorer.block_header
       parameters:
         - in: query
           name: block_num
@@ -269,7 +269,7 @@ paths:
   "/get_block":
     get:
       description: Get full block data
-      operationId: get_header
+      operationId: api.explorer.get_block
       parameters:
         - in: query
           name: block_num
@@ -288,7 +288,7 @@ paths:
   "/get_ticker":
     get:
       description: Get ticker data for a market
-      operationId: get_ticker
+      operationId: api.explorer.get_ticker
       parameters:
         - in: query
           name: base
@@ -313,7 +313,7 @@ paths:
   "/get_volume":
     get:
       description: Get 24hs volume data for a market
-      operationId: get_volume
+      operationId: api.explorer.get_volume
       parameters:
         - in: query
           name: base
@@ -338,7 +338,7 @@ paths:
   "/lastnetworkops":
     get:
       description: Get the last 10 operations made in the blockchain.
-      operationId: lastnetworkops
+      operationId: api.explorer.lastnetworkops
       responses:
         '200':
           description: Last 10 operations made in the network.
@@ -350,7 +350,7 @@ paths:
   "/get_object":
     get:
       description: Get object from ID
-      operationId: get_object
+      operationId: api.explorer.get_object
       parameters:
         - in: query
           name: object
@@ -369,7 +369,7 @@ paths:
   "/get_asset_holders_count":
     get:
       description: Get a count of holders and asset haves.
-      operationId: get_asset_holders_count
+      operationId: api.explorer.get_asset_holders_count
       parameters:
         - in: query
           name: asset_id
@@ -388,7 +388,7 @@ paths:
   "/get_asset_holders":
     get:
       description: Get asset holders for an asset.
-      operationId: get_asset_holders
+      operationId: api.explorer.get_asset_holders
       parameters:
         - in: query
           name: asset_id
@@ -400,13 +400,13 @@ paths:
           name: start
           default: 0
           type: integer
-          required: true
+          required: false
           description: Pagination start
         - in: query
           name: limit
           default: 0
           type: integer
-          required: true
+          required: false
           description: Number of records to retreive
       responses:
         '200':
@@ -419,7 +419,7 @@ paths:
   "/get_workers":
     get:
       description: Get all workers.
-      operationId: get_workers
+      operationId: api.explorer.get_workers
       responses:
         '200':
           description: All workers ever submitted to the network.
@@ -431,7 +431,7 @@ paths:
   "/get_markets":
     get:
       description: Get all the active markets for an asset.
-      operationId: get_markets
+      operationId: api.explorer.get_markets
       parameters:
         - in: query
           name: asset_id
@@ -450,7 +450,7 @@ paths:
   "/get_most_active_markets":
     get:
       description: Get the most active 100 markets in the network.
-      operationId: get_most_active_markets
+      operationId: api.explorer.get_most_active_markets
       responses:
         '200':
           description: 100 top markets
@@ -462,7 +462,7 @@ paths:
   "/get_order_book":
     get:
       description: Get the order book of a market.
-      operationId: get_order_book
+      operationId: api.explorer.get_order_book
       parameters:
         - in: query
           name: base
@@ -479,8 +479,8 @@ paths:
         - in: query
           name: limit
           default: 100
-          type: string
-          required: true
+          type: integer
+          required: false
           description: Number of records to retreive
       responses:
         '200':
@@ -493,7 +493,7 @@ paths:
   "/get_margin_positions":
     get:
       description: Get margin positions of an account.
-      operationId: get_margin_positions
+      operationId: api.explorer.get_margin_positions
       parameters:
         - in: query
           name: account_id
@@ -513,7 +513,7 @@ paths:
   "/get_witnesses":
     get:
       description: Get all witnesses.
-      operationId: get_witnesses
+      operationId: api.explorer.get_witnesses
       responses:
         '200':
           description: All witnesses in the network
@@ -526,7 +526,7 @@ paths:
   "/get_committee_members":
     get:
       description: Get all committee members.
-      operationId: get_committee_members
+      operationId: api.explorer.get_committee_members
       responses:
         '200':
           description: All committee members in the network
@@ -539,7 +539,7 @@ paths:
   "/market_chart_dates":
     get:
       description: Utility, get the dates of the last 30 days
-      operationId: market_chart_dates
+      operationId: api.explorer.market_chart_dates
       responses:
         '200':
           description: Array of dates of the last 30 days
@@ -551,7 +551,7 @@ paths:
   "/market_chart_data":
     get:
       description: Get OHLC chart data
-      operationId: market_chart_data
+      operationId: api.explorer.market_chart_data
       parameters:
         - in: query
           name: base
@@ -576,7 +576,7 @@ paths:
   "/top_proxies":
     get:
       description: Get the top proxies
-      operationId: top_proxies
+      operationId: api.explorer.top_proxies
       responses:
         '200':
           description: Top X proxies
@@ -589,7 +589,7 @@ paths:
   "/top_holders":
     get:
       description: Get the top holders
-      operationId: top_holders
+      operationId: api.explorer.top_holders
       responses:
         '200':
           description: Top X holders
@@ -602,7 +602,7 @@ paths:
   "/witnesses_votes":
     get:
       description: Get witness votes
-      operationId: witnesses_votes
+      operationId: api.explorer.witnesses_votes
       responses:
         '200':
           description: Witnesses votes
@@ -615,7 +615,7 @@ paths:
   "/workers_votes":
     get:
       description: Get worker votes
-      operationId: workers_votes
+      operationId: api.explorer.workers_votes
       responses:
         '200':
           description: Worker votes
@@ -628,7 +628,7 @@ paths:
   "/committee_votes":
     get:
       description: Get committee votes
-      operationId: committee_votes
+      operationId: api.explorer.committee_votes
       responses:
         '200':
           description: Committee votes
@@ -641,7 +641,7 @@ paths:
   "/top_markets":
     get:
       description: Top markets
-      operationId: top_markets
+      operationId: api.explorer.top_markets
       responses:
         '200':
           description: Top markets
@@ -653,7 +653,7 @@ paths:
   "/top_smartcoins":
     get:
       description: Top smartcoins
-      operationId: top_smartcoins
+      operationId: api.explorer.top_smartcoins
       responses:
         '200':
           description: Top smartcoins
@@ -665,7 +665,7 @@ paths:
   "/top_uias":
     get:
       description: Top User Issued Assets
-      operationId: top_uias
+      operationId: api.explorer.top_uias
       responses:
         '200':
           description: Top uias
@@ -677,7 +677,7 @@ paths:
   "/top_operations":
     get:
       description: Top Operations
-      operationId: top_operations
+      operationId: api.explorer.top_operations
       responses:
         '200':
           description: Top ops
@@ -689,7 +689,7 @@ paths:
   "/last_network_transactions":
     get:
       description: last 20 network transactions
-      operationId: last_network_transactions
+      operationId: api.explorer.last_network_transactions
       responses:
         '200':
           description: last network ops
@@ -701,7 +701,7 @@ paths:
   "/lookup_accounts":
     get:
       description: Search account by its name start
-      operationId: lookup_accounts
+      operationId: api.explorer.lookup_accounts
       parameters:
         - in: query
           name: start
@@ -720,7 +720,7 @@ paths:
   "/lookup_assets":
     get:
       description: Search asset by its name start
-      operationId: lookup_assets
+      operationId: api.explorer.lookup_assets
       parameters:
         - in: query
           name: start
@@ -739,7 +739,7 @@ paths:
   "/getlastblocknumbher":
     get:
       description: Get current block number
-      operationId: getlastblocknumbher
+      operationId: api.explorer.getlastblocknumber
       responses:
         '200':
           description:  last known block number
@@ -751,7 +751,7 @@ paths:
   "/account_history_pager":
     get:
       description: Get history of account by pages(need full node)
-      operationId: account_history_pager
+      operationId: api.explorer.account_history_pager
       parameters:
         - in: query
           name: account_id
@@ -777,7 +777,7 @@ paths:
   "/account_history_pager_elastic":
     get:
       description: Get history of account by pages(need elasticsearch node)
-      operationId: account_history_pager_elastic
+      operationId: api.explorer.account_history_pager_elastic
       parameters:
         - in: query
           name: account_id
@@ -803,7 +803,7 @@ paths:
   "/get_limit_orders":
     get:
       description: Get open limit orders of a market
-      operationId: get_limit_orders
+      operationId: api.explorer.get_limit_orders
       parameters:
         - in: query
           name: base
@@ -828,7 +828,7 @@ paths:
   "/get_call_orders":
     get:
       description: Get open call orders of a market
-      operationId: get_call_orders
+      operationId: api.explorer.get_call_orders
       parameters:
         - in: query
           name: asset_id
@@ -847,7 +847,7 @@ paths:
   "/get_settle_orders":
     get:
       description: Get open settle orders of a market
-      operationId: get_settle_orders
+      operationId: api.explorer.get_settle_orders
       parameters:
         - in: query
           name: base
@@ -872,7 +872,7 @@ paths:
   "/get_dex_total_volume":
     get:
       description: Get some total dex volume figures
-      operationId: get_dex_total_volume
+      operationId: api.explorer.get_dex_total_volume
       responses:
         '200':
           description:  dex total volume figures
@@ -884,7 +884,7 @@ paths:
   "/daily_volume_dex_dates":
     get:
       description: Get 60 days with of dates
-      operationId: daily_volume_dex_dates
+      operationId: api.explorer.daily_volume_dex_dates
       responses:
         '200':
           description:  60 days of dates
@@ -896,7 +896,7 @@ paths:
   "/daily_volume_dex_data":
     get:
       description: Get 60 days od plot volume data
-      operationId: daily_volume_dex_data
+      operationId: api.explorer.daily_volume_dex_data
       responses:
         '200':
           description: 60 days of plot data
@@ -908,7 +908,7 @@ paths:
   "/get_all_asset_holders":
     get:
       description: Get all holders of an asset
-      operationId: get_all_asset_holders
+      operationId: api.explorer.get_all_asset_holders
       parameters:
         - in: query
           name: asset_id
@@ -928,7 +928,7 @@ paths:
   "/referrer_count":
     get:
       description: Get number of referrers an account made
-      operationId: referrer_count
+      operationId: api.explorer.referrer_count
       parameters:
         - in: query
           name: account_id
@@ -948,7 +948,7 @@ paths:
   "/get_all_referrers":
     get:
       description: Get referrers an account made
-      operationId: get_all_referrers
+      operationId: api.explorer.get_all_referrers
       parameters:
         - in: query
           name: account_id
@@ -960,7 +960,7 @@ paths:
           name: page
           default: 0
           type: integer
-          required: true
+          required: false
           description: page
       responses:
         '200':
@@ -974,7 +974,7 @@ paths:
   "/get_grouped_limit_orders":
     get:
       description: Get the grouped order for a market
-      operationId: get_grouped_limit_orders
+      operationId: api.explorer.get_grouped_limit_orders
       parameters:
         - in: query
           name: base
@@ -992,13 +992,13 @@ paths:
           name: group
           default: 10
           type: integer
-          required: true
+          required: false
           description: group
         - in: query
           name: limit
-          default: 0
+          default: 10
           type: integer
-          required: true
+          required: false
           description: limit
       responses:
         '200':

--- a/app.ini
+++ b/app.ini
@@ -5,7 +5,7 @@ master = true
 processes = 8
 maximum-requests = 200
 
-socket = /tmp/api.sock
+socket = /tmp/app.sock
 chmod-socket = 666
 stats = /tmp/stats.socket
 lazy-apps = true

--- a/app.py
+++ b/app.py
@@ -1,0 +1,13 @@
+from flask_cors import CORS
+import connexion
+
+options = {'swagger_url': '/apidocs'}
+app = connexion.FlaskApp('bitshares-explorer-api', options=options)
+CORS(app.app)
+app.add_api('api.yaml')
+application = app.app
+
+if __name__ == "__main__":
+    app.run(host='0.0.0.0', port=5000)
+
+

--- a/config.py
+++ b/config.py
@@ -1,18 +1,17 @@
 import os
 
 
-WEBSOCKET_URL = os.environ.get('WEBSOCKET_URL', "ws://localhost:8090/ws")
-#WEBSOCKET_PUBLIC_HELPER = os.environ.get('WEBSOCKET_URL', "wss://node.bitshares.eu/ws")
+WEBSOCKET_URL = os.environ.get('WEBSOCKET_URL', "ws://127.0.0.1:8090/ws")
+WEBSOCKET_PUBLIC_HELPER = os.environ.get('WEBSOCKET_URL', "wss://node.bitshares.eu/ws")
 
 POSTGRES = {'host': os.environ.get('POSTGRES_HOST', 'localhost'),
-            'port': os.environ.get('POSTGRES_PORT', '5432'),
             'database': os.environ.get('POSTGRES_DATABASE', 'explorer'),
             'user': os.environ.get('POSTGRES_USER', 'postgres'),
             'password': os.environ.get('POSTGRES_PASSWORD', 'posta'),
 }
 
 # a connection to a bitshares full node
-FULL_WEBSOCKET_URL = os.environ.get('FULL_WEBSOCKET_URL', "wss://api.fr.bitsharesdex.com")
+FULL_WEBSOCKET_URL = os.environ.get('FULL_WEBSOCKET_URL', "ws://88.99.145.10:9999/ws")
 
 # a connection to an ElasticSearch wrapper
 #ES_WRAPPER = os.environ.get('ES_WRAPPER', "http://185.208.208.184:5000")
@@ -24,5 +23,5 @@ ES_WRAPPER = os.environ.get('ES_WRAPPER', "http://95.216.32.252:5000")
 CORE_ASSET_SYMBOL = 'BTS'
 CORE_ASSET_ID = '1.3.0'
 
-TESTNET = 1 # 0 = not in the testnet, 1 = testnet
+TESTNET = 0 # 0 = not in the testnet, 1 = testnet
 CORE_ASSET_SYMBOL_TESTNET = 'TEST'

--- a/config.py
+++ b/config.py
@@ -1,17 +1,18 @@
 import os
 
 
-WEBSOCKET_URL = os.environ.get('WEBSOCKET_URL', "ws://127.0.0.1:8090/ws")
-WEBSOCKET_PUBLIC_HELPER = os.environ.get('WEBSOCKET_URL', "wss://node.bitshares.eu/ws")
+WEBSOCKET_URL = os.environ.get('WEBSOCKET_URL', "ws://localhost:8090/ws")
+#WEBSOCKET_PUBLIC_HELPER = os.environ.get('WEBSOCKET_URL', "wss://node.bitshares.eu/ws")
 
 POSTGRES = {'host': os.environ.get('POSTGRES_HOST', 'localhost'),
+            'port': os.environ.get('POSTGRES_PORT', '5432'),
             'database': os.environ.get('POSTGRES_DATABASE', 'explorer'),
             'user': os.environ.get('POSTGRES_USER', 'postgres'),
             'password': os.environ.get('POSTGRES_PASSWORD', 'posta'),
 }
 
 # a connection to a bitshares full node
-FULL_WEBSOCKET_URL = os.environ.get('FULL_WEBSOCKET_URL', "ws://88.99.145.10:9999/ws")
+FULL_WEBSOCKET_URL = os.environ.get('FULL_WEBSOCKET_URL', "wss://api.fr.bitsharesdex.com")
 
 # a connection to an ElasticSearch wrapper
 #ES_WRAPPER = os.environ.get('ES_WRAPPER', "http://185.208.208.184:5000")
@@ -23,5 +24,5 @@ ES_WRAPPER = os.environ.get('ES_WRAPPER', "http://95.216.32.252:5000")
 CORE_ASSET_SYMBOL = 'BTS'
 CORE_ASSET_ID = '1.3.0'
 
-TESTNET = 0 # 0 = not in the testnet, 1 = testnet
+TESTNET = 1 # 0 = not in the testnet, 1 = testnet
 CORE_ASSET_SYMBOL_TESTNET = 'TEST'

--- a/postgres/import_assets.py
+++ b/postgres/import_assets.py
@@ -4,7 +4,7 @@ import json
 import psycopg2
 from websocket import create_connection
 
-import api
+import api.explorer
 import config
 
 ws = create_connection(config.WEBSOCKET_URL)
@@ -66,7 +66,7 @@ for x in range(0, len(all_assets)):
 
         precision = 5
         try:
-            data3 = api._get_asset(asset_id)
+            data3 = api.explorer._get_asset(asset_id)
             current_supply = data3["current_supply"]
             precision = data3["precision"]
         except:
@@ -74,7 +74,7 @@ for x in range(0, len(all_assets)):
             continue
 
         try:
-            holders = api._get_asset_holders_count(asset_id)
+            holders = api.explorer._get_asset_holders_count(asset_id)
         except:
             holders = 0
             continue
@@ -88,7 +88,7 @@ for x in range(0, len(all_assets)):
         #print all_assets[x]["result"][i]
 
         try:
-            data = api._get_volume(core_symbol, symbol)
+            data = api.explorer._get_volume(core_symbol, symbol)
         except:
             continue
 
@@ -96,7 +96,7 @@ for x in range(0, len(all_assets)):
         print data["quote_volume"]
 
         try:
-            data2 = api._get_ticker(core_symbol, symbol)
+            data2 = api.explorer._get_ticker(core_symbol, symbol)
             price = data2["latest"]
             #print price
 
@@ -142,10 +142,10 @@ con.commit()
 """
 
 # insert core token manually
-data3 = api._get_asset(config.CORE_ASSET_ID)
+data3 = api.explorer._get_asset(config.CORE_ASSET_ID)
 current_supply = data3["current_supply"]
 
-holders = api._get_asset_holders_count(config.CORE_ASSET_ID)
+holders = api.explorer._get_asset_holders_count(config.CORE_ASSET_ID)
 
 mcap = int(current_supply)
 

--- a/postgres/import_assets.py
+++ b/postgres/import_assets.py
@@ -67,8 +67,8 @@ for x in range(0, len(all_assets)):
         precision = 5
         try:
             data3 = api._get_asset(asset_id)
-            current_supply = data3[0]["current_supply"]
-            precision = data3[0]["precision"]
+            current_supply = data3["current_supply"]
+            precision = data3["precision"]
         except:
             price = 0
             continue
@@ -143,7 +143,7 @@ con.commit()
 
 # insert core token manually
 data3 = api._get_asset(config.CORE_ASSET_ID)
-current_supply = data3[0]["current_supply"]
+current_supply = data3["current_supply"]
 
 holders = api._get_asset_holders_count(config.CORE_ASSET_ID)
 

--- a/postgres/import_markets.py
+++ b/postgres/import_markets.py
@@ -4,7 +4,7 @@ import json
 import psycopg2
 from websocket import create_connection
 
-import api
+import api.explorer
 import config
 
 
@@ -51,14 +51,14 @@ for row in rows:
                 id_ = all_assets[x]["result"][i]["id"]
 
                 try:
-                    data = api._get_volume(symbol, row[1])
+                    data = api.explorer._get_volume(symbol, row[1])
                     volume = data["base_volume"]
                 except:
                     volume = 0
                     continue
 
                 try:
-                    data2 = api._get_ticker(symbol, row[1])
+                    data2 = api.explorer._get_ticker(symbol, row[1])
                     price = data2["latest"]
                     #print price
                 except:

--- a/postgres/import_realtime_ops.py
+++ b/postgres/import_realtime_ops.py
@@ -5,7 +5,7 @@ import thread
 import psycopg2
 import websocket
 
-import api
+import api.explorer
 import config
 
 
@@ -18,15 +18,15 @@ def on_message(ws, message):
         #print id_[:4]
         if id_[:4] == "2.9.":
             #print j["params"][1][0][0]
-            data = api._get_object(id_)
+            data = api.explorer._get_object(id_)
             #print data[0]
             account_id = data[0]["account"]
-            data_a = api._account(account_id)
+            data_a = api.explorer._account(account_id)
 
             #print data_a[0]["name"]
             account_name = data_a[0]["name"]
 
-            data2 = api._get_object(data[0]['operation_id'])
+            data2 = api.explorer._get_object(data[0]['operation_id'])
             block_num = data2[0]["block_num"]
 
             op_type = data2[0]["op"][0]

--- a/postgres/import_realtime_ops.py
+++ b/postgres/import_realtime_ops.py
@@ -7,6 +7,9 @@ import websocket
 
 import api.explorer
 import config
+from services.bitshares_websocket_client import BitsharesWebsocketClient
+
+bitshares_ws_client = BitsharesWebsocketClient(config.WEBSOCKET_URL)
 
 
 def on_message(ws, message):
@@ -18,28 +21,28 @@ def on_message(ws, message):
         #print id_[:4]
         if id_[:4] == "2.9.":
             #print j["params"][1][0][0]
-            data = api.explorer._get_object(id_)
+            data = bitshares_ws_client.get_object(id_)
             #print data[0]
-            account_id = data[0]["account"]
+            account_id = data["account"]
             data_a = api.explorer._account(account_id)
 
             #print data_a[0]["name"]
             account_name = data_a[0]["name"]
 
-            data2 = api.explorer._get_object(data[0]['operation_id'])
-            block_num = data2[0]["block_num"]
+            data2 = bitshares_ws_client.get_object(data['operation_id'])
+            block_num = data2["block_num"]
 
-            op_type = data2[0]["op"][0]
+            op_type = data2["op"][0]
 
             #print block_num
-            trx_in_block =  data2[0]["trx_in_block"]
-            op_in_trx =  data2[0]["op_in_trx"]
+            trx_in_block =  data2["trx_in_block"]
+            op_in_trx =  data2["op_in_trx"]
 
             con = psycopg2.connect(**config.POSTGRES)
             cur = con.cursor()
             query = "INSERT INTO ops (oh, ath, block_num, trx_in_block, op_in_trx, datetime, account_id, op_type, account_name) VALUES(%s, %s, %s, %s, %s, NOW(), %s, %s, %s)"
             print query
-            cur.execute(query, (id_, data[0]['operation_id'], str(block_num), str(trx_in_block), str(op_in_trx), account_id, str(op_type), account_name))
+            cur.execute(query, (id_, data['operation_id'], str(block_num), str(trx_in_block), str(op_in_trx), account_id, str(op_type), account_name))
             con.commit()
     except:
         pass

--- a/postgres/import_realtime_ops.py
+++ b/postgres/import_realtime_ops.py
@@ -24,7 +24,7 @@ def on_message(ws, message):
             data = bitshares_ws_client.get_object(id_)
             #print data[0]
             account_id = data["account"]
-            data_a = api.explorer._account(account_id)
+            data_a = api.explorer.account(account_id)
 
             #print data_a[0]["name"]
             account_name = data_a[0]["name"]

--- a/requirements/production.pip
+++ b/requirements/production.pip
@@ -1,8 +1,8 @@
 flask
 flask-cors
+connexion
 websocket-client
 psycopg2-binary
 schedule
-flasgger
 simplejson
 uwsgi==2.0.15

--- a/services/bitshares_websocket_client.py
+++ b/services/bitshares_websocket_client.py
@@ -25,11 +25,11 @@ class BitsharesWebsocketClient():
             ]
         }
         request_string = json.dumps(payload) 
-        print('> {}'.format(request_string))
+        #print('> {}'.format(request_string))
         self.ws.send(request_string)
         self.request_id += 1
         reply =  self.ws.recv()
-        print('< {}'.format(reply))
+        #print('< {}'.format(reply))
 
         ret = {}
         try:
@@ -51,4 +51,7 @@ class BitsharesWebsocketClient():
             api_id = self.request('login', api, [])
             self.api_ids[api] = api_id
         return self.api_ids[api]
+
+    def get_object(self, object_id):
+        return self.request('database', 'get_objects', [[object_id]])[0]
         

--- a/services/bitshares_websocket_client.py
+++ b/services/bitshares_websocket_client.py
@@ -25,11 +25,11 @@ class BitsharesWebsocketClient():
             ]
         }
         request_string = json.dumps(payload) 
-        #print('> {}'.format(request_string))
+        print('> {}'.format(request_string))
         self.ws.send(request_string)
         self.request_id += 1
         reply =  self.ws.recv()
-        #print('< {}'.format(reply))
+        print('< {}'.format(reply))
 
         ret = {}
         try:

--- a/tests/bitshares_websocket_client_test.py
+++ b/tests/bitshares_websocket_client_test.py
@@ -1,14 +1,20 @@
 import pytest
 
-from repositories.bitshares_websocket_client import BitsharesWebsocketClient
+from services.bitshares_websocket_client import BitsharesWebsocketClient
 import config
 
-def test_ws_request():
-    bitshares_client = BitsharesWebsocketClient(config.WEBSOCKET_URL)
+@pytest.fixture
+def bitshares_client():
+    return BitsharesWebsocketClient(config.WEBSOCKET_URL)
+
+def test_ws_request(bitshares_client):
     response = bitshares_client.request('database', "get_dynamic_global_properties", [])
     assert response['id'] == '2.1.0'
     assert 'head_block_number' in response
 
-def test_automatic_api_id_retrieval():
-    bitshares_client = BitsharesWebsocketClient(config.WEBSOCKET_URL)
+def test_automatic_api_id_retrieval(bitshares_client):
     bitshares_client.request('asset', 'get_asset_holders', ['1.3.0', 0, 100])
+
+def test_get_object(bitshares_client):
+    object = bitshares_client.get_object('1.3.0')
+    assert object

--- a/uwsgi.ini
+++ b/uwsgi.ini
@@ -20,6 +20,6 @@ die-on-term = true
 harakiri = 30
 post-buffering = 1
 single-interpreter = True
-# We can't enable threading because the websocket connection is shared on module level (in api.py)
+# We can't enable threading because the websocket connection is shared on module level (in app.py)
 # and does not have the capability to pair responses to requests based on ID.
 enable-threads = False

--- a/wsgi.py
+++ b/wsgi.py
@@ -1,4 +1,0 @@
-from api import app
-
-if __name__ == "__main__":
-    app.run()


### PR DESCRIPTION
This continue the work started at: https://github.com/oxarbitrage/explorer-api/pull/25

Main changes:

- Introduction of [Zalando/connexion](https://github.com/zalando/connexion) (see rationale below).
- Fix issue in `import_asset.py` introduced in previous PR. (see https://github.com/Zapata/bitshares-python-api-backend/commit/ae7b7263436d2bed3cae0d1ecac6141dda0837c6)
- Review for loops to use iterators instead of range.
- Factorize and simplify code.


Why  'Connexion'?
-  it hides Swagger management code and do full validations of the spec at startup.
-  it magically maps routes to function and parameters using swagger specs (and `operationId` field), see [doc](https://github.com/zalando/connexion#endpoint-routing-to-your-python-views).
-  it manage json conversion everywhere (no more jsonify, and exception are serialized in json properly)
-  it has some [mock](https://connexion.readthedocs.io/en/latest/cli.html#running-a-mock-server)/[stub ](https://connexion.readthedocs.io/en/latest/cli.html#running-an-openapi-specification) features
-   - it helps split the code in submodules
-   - it allow to switch server implementation easely for performance tuning, see [doc](https://github.com/zalando/connexion#server-backend).

This is an intermediary pull request in order to merge regularly. More cleanup to come. 
Full renaming to explorer-api will be in the next PR.
Non regression test against [ref_for_non_reg](https://github.com/Zapata/bitshares-python-api-backend/tree/ref_for_non_reg) have passed.