### PR TITLE
Merge oxarbitrage/bitshares-es-wrapper into bitshares-explorer-api.

### DIFF
--- a/api/es_wrapper.py
+++ b/api/es_wrapper.py
@@ -1,0 +1,59 @@
+from elasticsearch import Elasticsearch
+from elasticsearch_dsl import Search, Q
+import config
+
+if      'user' in config.ELASTICSEARCH and config.ELASTICSEARCH['user'] \
+    and 'password' in config.ELASTICSEARCH and config.ELASTICSEARCH['password']:
+    es = Elasticsearch(config.ELASTICSEARCH['hosts'], \
+                        http_auth=(config.ELASTICSEARCH['user'], config.ELASTICSEARCH['password']),\
+                        timeout=60)
+else:
+    es = Elasticsearch(config.ELASTICSEARCH['hosts'], timeout=60)
+
+
+def get_account_history(account_id=None, operation_type=None, from_=0, size=10, 
+                        from_date='2015-10-10', to_date='now', sort_by='-block_data.block_time',
+                        type='data', agg_field='operation_type'):
+    if type != "data":
+        s = Search(using=es, index="bitshares-*")
+    else:
+        s = Search(using=es, index="bitshares-*", extra={"size": size, "from": from_})
+
+    q = Q()
+
+    if account_id:
+        q = q & Q("match", account_history__account=account_id)
+    if operation_type:
+        q = q & Q("match", operation_type=operation_type)
+
+    range_query = Q("range", block_data__block_time={'gte': from_date, 'lte': to_date})
+    s.query = q & range_query
+
+    if type != "data":
+        s.aggs.bucket('per_field', 'terms', field=agg_field, size=size)
+
+    s = s.sort(sort_by)
+    print(s.to_dict())
+    response = s.execute()
+
+    if type == "data":
+        return [ hit.to_dict() for hit in response ]
+    else:
+        return [ field.to_dict() for field in response.aggregations.per_field.buckets ]
+
+
+def get_single_operation(operation_id):
+    s = Search(using=es, index="bitshares-*", extra={"size": 1})
+    s.query = Q("match", account_history__operation_id=operation_id)
+
+    response = s.execute()
+
+    return [ hit.to_dict() for hit in response ]
+
+def get_trx(trx, from_=0, size=10):
+    s = Search(using=es, index="bitshares-*", extra={"size": size, "from": from_})
+    s.query = Q("match", block_data__trx_id=trx)
+
+    response = s.execute()
+
+    return [ hit.to_dict() for hit in response ]

--- a/api/es_wrapper.py
+++ b/api/es_wrapper.py
@@ -1,14 +1,5 @@
-from elasticsearch import Elasticsearch
 from elasticsearch_dsl import Search, Q
-import config
-
-if      'user' in config.ELASTICSEARCH and config.ELASTICSEARCH['user'] \
-    and 'password' in config.ELASTICSEARCH and config.ELASTICSEARCH['password']:
-    es = Elasticsearch(config.ELASTICSEARCH['hosts'], \
-                        http_auth=(config.ELASTICSEARCH['user'], config.ELASTICSEARCH['password']),\
-                        timeout=60)
-else:
-    es = Elasticsearch(config.ELASTICSEARCH['hosts'], timeout=60)
+from services.elasticsearch_client import es
 
 
 def get_account_history(account_id=None, operation_type=None, from_=0, size=10, 
@@ -33,7 +24,6 @@ def get_account_history(account_id=None, operation_type=None, from_=0, size=10,
         s.aggs.bucket('per_field', 'terms', field=agg_field, size=size)
 
     s = s.sort(sort_by)
-    print(s.to_dict())
     response = s.execute()
 
     if type == "data":

--- a/app.py
+++ b/app.py
@@ -1,7 +1,8 @@
 import connexion
 
 options = {'swagger_url': '/apidocs'}
-app = connexion.FlaskApp('bitshares-explorer-api', options=options)
+# strict_validation=True: requests that include parameters not defined return a 400 error
+app = connexion.App('bitshares-explorer-api', specification_dir='swagger/', options=options)
 
 from flask_cors import CORS
 CORS(app.app)
@@ -9,7 +10,14 @@ CORS(app.app)
 from services.cache import cache
 cache.init_app(app.app)
 
-app.add_api('api.yaml')
+from specsynthase.specbuilder import SpecBuilder
+import glob
+from os import path
+
+spec = SpecBuilder()
+for spec_file in glob.glob(path.join(path.dirname(__file__), 'swagger/*')):
+    spec.add_spec(spec_file)
+app.add_api(spec)
 
 import services.profiler
 services.profiler.init_app(app.app)

--- a/config.py
+++ b/config.py
@@ -10,6 +10,15 @@ FULL_WEBSOCKET_URL = os.environ.get('FULL_WEBSOCKET_URL', "ws://88.99.145.10:999
 ES_WRAPPER = os.environ.get('ES_WRAPPER', "http://95.216.32.252:5000") # clockwork
 #ES_WRAPPER = os.environ.get('ES_WRAPPER', "https://eswrapper.bitshares.eu") # Infrastructure worker
 
+# a connection to Elastic Search.
+# oxarbitrage
+ELASTICSEARCH = {
+    'hosts': os.environ.get('ELASTICSEARCH_URL', 'http://148.251.10.231:5005/').split(','),
+    'user': os.environ.get('ELASTICSEARCH_USER', None),
+    'password': os.environ.get('ELASTICSEARCH_USER', None)
+}
+
+
 # Database connection: see https://www.postgresql.org/docs/current/static/libpq-connect.html#LIBPQ-PARAMKEYWORDS
 POSTGRES = {'host': os.environ.get('POSTGRES_HOST', 'localhost'),
             'port': os.environ.get('POSTGRES_PORT', '5432'),

--- a/config.py
+++ b/config.py
@@ -5,11 +5,6 @@ WEBSOCKET_URL = os.environ.get('WEBSOCKET_URL', "ws://localhost:8090/ws")
 # a connection to a bitshares full node
 FULL_WEBSOCKET_URL = os.environ.get('FULL_WEBSOCKET_URL', "ws://88.99.145.10:9999/ws")
 
-# a connection to an ElasticSearch wrapper
-#ES_WRAPPER = os.environ.get('ES_WRAPPER', "http://185.208.208.184:5000") # oxarbitrage
-ES_WRAPPER = os.environ.get('ES_WRAPPER', "http://95.216.32.252:5000") # clockwork
-#ES_WRAPPER = os.environ.get('ES_WRAPPER', "https://eswrapper.bitshares.eu") # Infrastructure worker
-
 # a connection to Elastic Search.
 # oxarbitrage
 ELASTICSEARCH = {

--- a/non_reg/README.md
+++ b/non_reg/README.md
@@ -4,6 +4,7 @@ Test all API calls against a reference and a tested server, and compare results.
 
   - Start the Postgres database and import all data.
   - Start a witness with access to `asset_api` and `orders_api` configured.
-  - Run the reference server: `cd ref && flask run --port=5005`
+  - Run the reference Explorer API server: `cd ref && flask run --port=5005`
+  - Run the reference ES Wrapper server: `cd es-wrapper && flask run --port=5006`
   - Run the tested server: `cd actual && flask run --port=5000`
   - Run tests: `pytest -v check_non_regression.py`

--- a/non_reg/check_non_regression.py
+++ b/non_reg/check_non_regression.py
@@ -4,12 +4,19 @@ import requests
 from json_delta import diff, udiff
 from swagger_parser import SwaggerParser
 
-TESTED_URL = "http://localhost:5000"
-REF_URL = "http://localhost:5005"
+TESTED = {
+    'explorer-api': 'http://localhost:5000',
+    'es-wrapper': 'http://localhost:5000'
+}
 
-def test_request(path):
-    ref = requests.get(REF_URL + path)
-    actual = requests.get(TESTED_URL + path)
+REF = {
+  'explorer-api': 'http://localhost:5005',
+  'es-wrapper': 'http://localhost:5006',
+} 
+
+def test_request(service, path):
+    ref = requests.get(REF[service] + path)
+    actual = requests.get(TESTED[service] + path)
     assert actual.status_code == ref.status_code
     assert ref.status_code == 200
     json_diff = diff(actual.json(), ref.json(), array_align=False, verbose=False)

--- a/non_reg/conftest.py
+++ b/non_reg/conftest.py
@@ -1,13 +1,34 @@
+def _url_from_swagger_spec(path_name, path_spec):
+
+    if 'parameters' not in path_spec['get']:
+        return path_name
+
+    params = []
+    for param_spec in path_spec['get']['parameters']:
+        params.append('{}={}'.format(param_spec['name'], param_spec['default']))
+    return '{}?{}'.format(path_name, '&'.join(params))
+
+def _identify_service_from_tag(tags):
+    if 'api' in tags:
+        return 'explorer-api'
+    if 'wrapper' in tags:
+        return 'es-wrapper'
+    return None
+
 def pytest_generate_tests(metafunc):
     if 'path' in metafunc.fixturenames:
         from swagger_parser import SwaggerParser
+        from specsynthase.specbuilder import SpecBuilder
+        import glob
+        from os import path
 
-        parser = SwaggerParser(swagger_path='../api.yaml')
+        spec = SpecBuilder()
+        for spec_file in glob.glob(path.join(path.dirname(__file__), '../swagger/*')):
+            spec.add_spec(spec_file)
 
         requests = []
-        for path_name, path_spec in parser.paths.iteritems():
-            params = []
-            for param_name, param_spec in path_spec['get']['parameters'].iteritems():
-                params.append('{}={}'.format(param_name, param_spec['default']))
-            requests.append('{}{}'.format(path_name, '' if not params else '?{}'.format('&'.join(params))))
-        metafunc.parametrize("path", requests)
+        for path_name, path_spec in spec['paths'].iteritems():
+            url = _url_from_swagger_spec(path_name, path_spec)
+            service = _identify_service_from_tag(path_spec['get']['tags'])
+            requests.append((service, url))
+        metafunc.parametrize("service,path", requests)

--- a/non_reg/requirements.txt
+++ b/non_reg/requirements.txt
@@ -1,4 +1,3 @@
 pytest
 requests
 json_delta
-swagger_parser

--- a/requirements/production.pip
+++ b/requirements/production.pip
@@ -8,3 +8,6 @@ psycopg2
 schedule
 simplejson
 uwsgi==2.0.15
+elasticsearch>=6.0.0,<7.0.0
+elasticsearch-dsl>=5.0.0,<6.0.0
+spec-synthase

--- a/services/elasticsearch_client.py
+++ b/services/elasticsearch_client.py
@@ -1,0 +1,10 @@
+from elasticsearch import Elasticsearch
+import config
+
+if      'user' in config.ELASTICSEARCH and config.ELASTICSEARCH['user'] \
+    and 'password' in config.ELASTICSEARCH and config.ELASTICSEARCH['password']:
+    es = Elasticsearch(config.ELASTICSEARCH['hosts'], \
+                        http_auth=(config.ELASTICSEARCH['user'], config.ELASTICSEARCH['password']),\
+                        timeout=60)
+else:
+    es = Elasticsearch(config.ELASTICSEARCH['hosts'], timeout=60)

--- a/swagger/api.yaml
+++ b/swagger/api.yaml
@@ -1,0 +1,10 @@
+swagger: '2.0'
+info:
+  title: BitShares Explorer API
+  description: Exposes BitShares calls needed to explore the blockchain
+  version: '1'
+schemes:
+  - http
+  - https
+produces:
+  - application/json

--- a/swagger/paths_es_wrapper.yaml
+++ b/swagger/paths_es_wrapper.yaml
@@ -1,0 +1,116 @@
+paths:
+  "/get_account_history":
+    get:
+      description: Get all operations in history with pager, similar to bitshares node call but with fullter features like search by date, filter by operation and others.
+      operationId: api.es_wrapper.get_account_history
+      parameters:
+        - in: query
+          name: account_id
+          default: "1.2.0"
+          type: string
+          required: false
+          description: Account id to get ops from
+        - in: query
+          name: operation_type
+          default: "0"
+          type: string
+          required: false
+          description: 1-44 Operation type
+        - in: query
+          name: from_
+          default: 0
+          type: integer
+          required: false
+          description: Record to start getting results
+        - in: query
+          name: size
+          default: 10
+          type: integer
+          required: false
+          description: Amount of records to get
+        - in: query
+          name: from_date
+          default: "2015-10-10"
+          type: string
+          required: false
+          description: Start date range
+        - in: query
+          name: to_date
+          default: "now"
+          type: string
+          required: false
+          description: End date range
+        - in: query
+          name: sort_by
+          default: "-block_data.block_time"
+          type: string
+          required: false
+          description: Order by an output field
+        - in: query
+          name: type
+          default: "data"
+          type: string
+          required: false
+          description: data or count
+        - in: query
+          name: agg_field
+          default: "operation_type"
+          type: string
+          required: false
+          description: For type data
+      responses:
+        '200':
+          description: Array of operation data
+        '500': 
+          description: Error processing parameters
+      tags:
+        - wrapper
+
+  "/get_single_operation":
+    get:
+      description: Get a single operation by the operation ID.
+      operationId: api.es_wrapper.get_single_operation
+      parameters:
+        - in: query
+          name: operation_id
+          default: "1.11.0"
+          type: string
+          required: true
+          description: Operation ID (1.11.X)
+      responses:
+        '200':
+          description: 1 record of operation data
+        '500':
+          description: Error processing parameters
+      tags:
+        - wrapper
+  "/get_trx":
+    get:
+      description: Get the operations inside a transaction hash.
+      operationId: api.es_wrapper.get_trx
+      parameters:
+        - in: query
+          name: trx
+          default: 738be2bd22e2da31d587d281ea7ee9bd02b9dbf0
+          type: string
+          required: true
+          description: Transaction hash
+        - in: query
+          name: from_
+          default: 0
+          type: integer
+          required: false
+          description: Record to start getting results
+        - in: query
+          name: size
+          default: 10
+          type: integer
+          required: false
+          description: Amount of records to get
+      responses:
+        '200':
+          description: Array of operations data
+        '500':
+          description: Error processing parameters
+      tags:
+        - wrapper

--- a/swagger/paths_explorer.yaml
+++ b/swagger/paths_explorer.yaml
@@ -1,13 +1,3 @@
-swagger: '2.0'
-info:
-  title: BitShares Excplorer API
-  description: Exposes BitShares calls needed to explore the blockchain
-  version: '1'
-schemes:
-  - http
-  - https
-produces:
-  - application/json
 paths:
   "/header":
     get:


### PR DESCRIPTION
Code has been integrated and reviewed.

No changes to the API have been done, and non regression test tool has been updated to check both explorer-api endpoint (tag = api) and es_wrapper endpoints (tag = es_wrapper).
 
New configuration has been introduced to `config.py`:

```
ELASTICSEARCH = {
    'hosts': os.environ.get('ELASTICSEARCH_URL', 'http://148.251.10.231:5005/').split(','),
    'user': os.environ.get('ELASTICSEARCH_USER', None),
    'password': os.environ.get('ELASTICSEARCH_USER', None)
}
```

To install:
  - run `pip install -r requirements\production.pip`
  - configure `ELASTICSEARCH` in configuration (`ES_WRAPPER` field could be removed)
  - ES Wrapper endpoints are accessible at root path, ie: `http://localhost:5000/get_single_operation?operation_id=1.11.0`