### PR TITLE
Add is alive

### DIFF
--- a/api/es_wrapper.py
+++ b/api/es_wrapper.py
@@ -1,5 +1,7 @@
 from elasticsearch_dsl import Search, Q
 from services.elasticsearch_client import es
+from elasticsearch.exceptions import NotFoundError
+from datetime import datetime, timedelta
 
 
 def get_account_history(account_id=None, operation_type=None, from_=0, size=10, 
@@ -39,6 +41,35 @@ def get_single_operation(operation_id):
     response = s.execute()
 
     return [ hit.to_dict() for hit in response ]
+
+
+def is_alive():
+    find_string = datetime.utcnow().strftime("%Y-%m")
+    from_date = (datetime.utcnow() - timedelta(days=1)).strftime("%Y-%m-%d")
+
+    s = Search(using=es, index="bitshares-" + find_string)
+    s.query = Q("range", block_data__block_time={'gte': from_date, 'lte': "now"})
+    s.aggs.metric("max_block_time", "max", field="block_data.block_time")
+
+    json_response = {
+        "server_time": datetime.utcnow(),
+        "head_block_timestamp": None,
+        "head_block_time": None
+    }
+
+    try:
+        response = s.execute()
+        json_response["head_block_time"] = str(response.aggregations.max_block_time.value_as_string)
+        json_response["head_block_timestamp"] = response.aggregations.max_block_time.value
+        json_response["deltatime"] = abs((datetime.utcfromtimestamp(json_response["head_block_timestamp"] / 1000) - json_response["server_time"]).total_seconds())
+        json_response["status"] = "ok" if json_response["deltatime"] < 30 else "out_of_sync"
+    except NotFoundError:
+        json_response["status"] = "out_of_sync_index_not_found"
+        json_response["deltatime"] = "Infinite",
+        json_response["query_index"] = find_string
+
+    return json_response
+
 
 def get_trx(trx, from_=0, size=10):
     s = Search(using=es, index="bitshares-*", extra={"size": size, "from": from_})

--- a/swagger/paths_es_wrapper.yaml
+++ b/swagger/paths_es_wrapper.yaml
@@ -82,6 +82,19 @@ paths:
           description: Error processing parameters
       tags:
         - wrapper
+
+  "/is_alive":
+    get:
+      description: Queries the latest head block and gives synchronization status of the elastic search database
+      operationId: api.es_wrapper.is_alive
+      responses:
+        '200':
+          description: json data with status, server_time and head_block_time and statistics
+        '500':
+          description: Error processing parameters
+      tags:
+        - wrapper
+
   "/get_trx":
     get:
       description: Get the operations inside a transaction hash.


### PR DESCRIPTION
Adds a json response that queries last head block, output is as below
```
{
  "deltatime": 0.52071,
  "head_block_time": "2019-01-24T11:16:57.000Z",
  "head_block_timestamp": 1548328617000.0,
  "server_time": "2019-01-24T11:16:57.520710Z",
  "status": "ok"
}
```

Possible `status` values are `ok` and `out_of_sync`, and in the latter a `error` indicator is added to the json. If ES is not reachable, a 500 is returned.