### PR TITLE
Api v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,20 @@ http://185.208.208.184:5000/apidocs/
 Index:
 
 - [BitShares Explorer REST API](#bitshares-explorer-rest-api)
-  - [Installation](#installation)
-    - [Manual](#manual)
-      - [Install ElasticSearch](#install-elasticsearch)
-      - [Install a BitShares node with requirements.](#install-a-bitshares-node-with-requirements)
-      - [Install BitShares Explorer API and dependencies.](#install-bitshares-explorer-api-and-dependencies)
+    - [Installation](#installation)
+        - [Manual](#manual)
+            - [Install ElasticSearch](#install-elasticsearch)
+            - [Install a BitShares node with requirements.](#install-a-bitshares-node-with-requirements)
+            - [Install BitShares Explorer API and dependencies.](#install-bitshares-explorer-api-and-dependencies)
+            - [Simple running](#simple-running)
+            - [Nginx and uwsgi](#nginx-and-uwsgi)
+            - [Domain setup and SSL](#domain-setup-and-ssl)
+        - [Docker](#docker)
+    - [Usage](#usage)
+        - [Swagger](#swagger)
+        - [Profiler](#profiler)
+        - [Open Explorer](#open-explorer)
+        - [Development](#development)
 
 ## Installation
 
@@ -275,10 +284,31 @@ All versions of open-explorer uses this backend to get data.
 
 ### Development
 
-Run tests:
+Run all tests:
 
 ```
 PYTHONPATH=. pytest
 ```
+
+This will also run API tests (using [Tavern](https://taverntesting.github.io/)), that needs an local server to run, so make sure your development server is started.
+
+To run one specific test:
+
+```
+PYTHONPATH=. pytest -k test_ws_request
+```
+
+Or for API tests:
+
+```
+ PYTHONPATH=. py.test tests/test_api_explorer.tavern.yaml -k get_asset_holders_count
+ ```
+
+You can run API tests on a non localhost server using the command:
+
+```
+ PYTHONPATH=. py.test tavern-global-cfg=your_customized_environment.yaml tests/test_api_explorer.tavern.yaml
+ ```
+ See `tests/local_urls.yaml` to see how to define a new environment.
 
 And for non regression see `non_reg/README.md`

--- a/api/es_wrapper.py
+++ b/api/es_wrapper.py
@@ -39,7 +39,7 @@ def get_single_operation(operation_id):
 
     response = s.execute()
 
-    return [ hit.to_dict() for hit in response ]
+    return [ hit.to_dict() for hit in response ][0]
 
 
 def is_alive():

--- a/api/explorer.py
+++ b/api/explorer.py
@@ -20,11 +20,11 @@ def get_header():
 
 @cache.memoize()
 def get_account(account_id):
-    return bitshares_ws_client.request('database', 'get_accounts', [[account_id]])
+    return bitshares_ws_client.request('database', 'get_accounts', [[account_id]])[0]
 
 def get_account_name(account_id):
     account = get_account(account_id)
-    return account[0]['name']
+    return account['name']
 
 @cache.memoize()
 def _get_account_id(account_name):
@@ -83,7 +83,7 @@ def get_accounts():
 
 
 def get_full_account(account_id):
-    account = bitshares_ws_client.request('database', 'get_full_accounts', [[account_id], 0])
+    account = bitshares_ws_client.request('database', 'get_full_accounts', [[account_id], 0])[0][1]
     return account
 
 
@@ -454,7 +454,7 @@ def _get_holders():
             if proxy_id != '1.2.5':
                 if proxy_id not in holders_by_account_id:
                     proxy_without_balance = {
-                        'owner': get_account(proxy_id)[0],
+                        'owner': get_account(proxy_id),
                         'balance': 0,
                         'asset_type': config.CORE_ASSET_ID
                     }

--- a/api/explorer.py
+++ b/api/explorer.py
@@ -564,13 +564,13 @@ def get_top_markets():
 
 
 def get_top_smartcoins():
-    smartcoins = [[a['asset_name'], a['24h_volume']] for a in get_assets() if a['asset_type'] == 'SmartCoin']
+    smartcoins = [a for a in get_assets() if a['asset_type'] == 'SmartCoin']
     return smartcoins[:7]
 
 
 @cache.memoize()
 def get_top_uias():
-    uias = [[a['asset_name'], a['24h_volume']] for a in get_assets() if a['asset_type'] == 'User Issued']
+    uias = [a for a in get_assets() if a['asset_type'] == 'User Issued']
     return uias[:7]
 
 

--- a/api/explorer.py
+++ b/api/explorer.py
@@ -60,7 +60,7 @@ def _enrich_operation(operation, ws_client):
 
     return _add_global_informations(operation, ws_client)
 
-def get_operation_full_elastic(operation_id):
+def get_operation(operation_id):
     res = es_wrapper.get_single_operation(operation_id)
     operation = { 
         "op": res[0]["operation_history"]["op_object"],

--- a/api/explorer.py
+++ b/api/explorer.py
@@ -184,7 +184,7 @@ def _get_volume(base, quote):
 
 
 def get_object(object):
-    return [ bitshares_ws_client.get_object(object) ]
+    return bitshares_ws_client.get_object(object)
 
 def _ensure_asset_id(asset_id):
     if not _is_object(asset_id):

--- a/api/explorer.py
+++ b/api/explorer.py
@@ -582,7 +582,7 @@ def get_last_block_number():
     return dynamic_global_properties["head_block_number"]
 
 
-def get_account_history_pager_elastic(account_id, page):
+def get_account_history(account_id, page):
     account_id = _get_account_id(account_id)
 
     from_ = int(page) * 20

--- a/api/explorer.py
+++ b/api/explorer.py
@@ -470,13 +470,12 @@ def get_top_holders():
     holders_without_vote_delegation.sort(key=lambda h : -int(h['balance']))
     top_holders = []
     for holder in holders_without_vote_delegation[:10]:
-        top_holders.append([
-            0,                            # (legacy) database id
-            holder['owner']['id'],        # account id
-            holder['owner']['name'],      # account name
-            int(holder['balance']),       # BTS amount
-            _get_voting_account(holder)   # voting account
-        ]) 
+        top_holders.append({
+            'account_id': holder['owner']['id'],
+            'account_name': holder['owner']['name'],
+            'amount': int(holder['balance']),
+            'voting_account': _get_voting_account(holder)
+        }) 
     return top_holders
 
 

--- a/api/explorer.py
+++ b/api/explorer.py
@@ -551,7 +551,7 @@ def get_top_markets():
     markets = get_most_active_markets()
     markets.sort(key=lambda a : -a['24h_volume']) # sort by volume
     top = markets[:7]
-    return [ [m['pair'], m['24h_volume']] for m in top ]
+    return top
 
 
 def get_top_smartcoins():

--- a/api/explorer.py
+++ b/api/explorer.py
@@ -312,9 +312,9 @@ def get_witnesses():
     for witness in witnesses:
         if witness:
             witness["witness_account_name"] = get_account_name(witness["witness_account"])
-            result.append([witness])
+            result.append(witness)
 
-    result = sorted(result, key=lambda k: int(k[0]['total_votes']))
+    result = sorted(result, key=lambda k: int(k['total_votes']))
     result = result[::-1] # Reverse list.
     return result
 
@@ -492,9 +492,9 @@ def get_witnesses_votes():
 
     witnesses_votes = []
     for witness in witnesses:
-        vote_id =  witness[0]["vote_id"]
-        id_witness = witness[0]["id"]
-        witness_account_name = witness[0]["witness_account_name"]
+        vote_id =  witness["vote_id"]
+        id_witness = witness["id"]
+        witness_account_name = witness["witness_account_name"]
         proxy_votes = _get_formatted_proxy_votes(proxies, vote_id)        
 
         witnesses_votes.append({

--- a/api/explorer.py
+++ b/api/explorer.py
@@ -395,15 +395,15 @@ def get_top_proxies():
         if 'follower_count' in holder:
             proxy_amount =  int(holder['balance']) + int(holder['follower_amount'])
             proxy_total_percentage = float(int(proxy_amount) * 100.0/ int(total_votes))
-            proxies.append([
-                holder['owner']['id'],
-                holder['owner']['name'],
-                proxy_amount,
-                holder['follower_count'],
-                proxy_total_percentage
-            ])
+            proxies.append({
+                'id': holder['owner']['id'],
+                'name': holder['owner']['name'],
+                'bts_weight': proxy_amount,
+                'followers': holder['follower_count'],
+                'bts_weight_percentage': proxy_total_percentage
+            })
 
-    proxies = sorted(proxies, key=lambda k: -k[2]) # Reverse amount order
+    proxies = sorted(proxies, key=lambda k: -k['bts_weight']) # Reverse amount order
 
     return proxies
 
@@ -490,7 +490,7 @@ def _get_formatted_proxy_votes(proxies, vote_id):
 def get_witnesses_votes():
     proxies = get_top_proxies()
     proxies = proxies[:10]
-    proxies = bitshares_ws_client.request('database', 'get_objects', [[ p[0] for p in proxies ]])
+    proxies = bitshares_ws_client.request('database', 'get_objects', [[ p['id'] for p in proxies ]])
 
     witnesses = get_witnesses()
     witnesses = witnesses[:25] # FIXME: Witness number is variable.
@@ -510,7 +510,7 @@ def get_witnesses_votes():
 def get_workers_votes():
     proxies = get_top_proxies()
     proxies = proxies[:10]
-    proxies = bitshares_ws_client.request('database', 'get_objects', [[ p[0] for p in proxies ]])
+    proxies = bitshares_ws_client.request('database', 'get_objects', [[ p['id'] for p in proxies ]])
 
     workers = get_workers()
     workers = workers[:30]
@@ -531,7 +531,7 @@ def get_workers_votes():
 def get_committee_votes():
     proxies = get_top_proxies()
     proxies = proxies[:10]
-    proxies = bitshares_ws_client.request('database', 'get_objects', [[ p[0] for p in proxies ]])
+    proxies = bitshares_ws_client.request('database', 'get_objects', [[ p['id'] for p in proxies ]])
 
     committee_members = get_committee_members()
     committee_members = committee_members[:11]

--- a/api/explorer.py
+++ b/api/explorer.py
@@ -681,7 +681,7 @@ def get_referrer_count(account_id):
 
     count, _ = bitshares_es_client.get_accounts_with_referrer(account_id, size=0)
 
-    return [count]
+    return count
 
 
 def get_all_referrers(account_id, page=0):

--- a/api/explorer.py
+++ b/api/explorer.py
@@ -63,15 +63,15 @@ def _enrich_operation(operation, ws_client):
 def get_operation(operation_id):
     res = es_wrapper.get_single_operation(operation_id)
     operation = { 
-        "op": res[0]["operation_history"]["op_object"],
-        "op_type": res[0]["operation_type"],
-        "block_num": res[0]["block_data"]["block_num"], 
-        "op_in_trx": res[0]["operation_history"]["op_in_trx"],
-        "result": json.loads(res[0]["operation_history"]["operation_result"]), 
-        "trx_in_block": res[0]["operation_history"]["trx_in_block"],
-        "virtual_op": res[0]["operation_history"]["virtual_op"], 
-        "block_time": res[0]["block_data"]["block_time"],
-        "trx_id": res[0]["block_data"]["trx_id"]
+        "op": res["operation_history"]["op_object"],
+        "op_type": res["operation_type"],
+        "block_num": res["block_data"]["block_num"], 
+        "op_in_trx": res["operation_history"]["op_in_trx"],
+        "result": json.loads(res["operation_history"]["operation_result"]), 
+        "trx_in_block": res["operation_history"]["trx_in_block"],
+        "virtual_op": res["operation_history"]["virtual_op"], 
+        "block_time": res["block_data"]["block_time"],
+        "trx_id": res["block_data"]["trx_id"]
     }
 
     operation = _enrich_operation(operation, bitshares_ws_client)

--- a/api/explorer.py
+++ b/api/explorer.py
@@ -98,22 +98,20 @@ def get_assets():
         asset = get_asset_and_volume(asset_id)
         holders_count = get_asset_holders_count(asset_id)
         bts_volume += float(asset['volume'])
-        results.append([
-            None, # db id (legacy, no purpose)
-            asset['symbol'], # asset name
-            asset_id, # asset id
-            asset['latest_price'], # price in bts
-            float(asset['volume']) if asset_id != config.CORE_ASSET_ID else bts_volume, # 24h volume
+        results.append({
+            'asset_name': asset['symbol'], # asset name
+            'asset_id': asset_id, # asset id
+            'latest_price': asset['latest_price'], # price in bts
+            '24h_volume': float(asset['volume']) if asset_id != config.CORE_ASSET_ID else bts_volume, # 24h volume
             #float(markets[asset_id][config.CORE_ASSET_ID]['volume']), # 24h volume (from ES) / should be divided by core asset precision
-            asset['mcap'], # market cap
-            _get_asset_type(asset), # type: Core Asset / Smart Asset / User Issued Asset
-            int(asset['current_supply']), # Supply
-            holders_count, #Number of holders
-            '', # Wallet Type (useless value)
-            asset['precision'] # Asset precision
-        ])
+            'market_cap': asset['mcap'], # market cap
+            'asset_type': _get_asset_type(asset), # type: Core Asset / Smart Asset / User Issued Asset
+            'current_supply': int(asset['current_supply']), # Supply
+            'holders_count': holders_count, #Number of holders
+            'precision': asset['precision'] # Asset precision
+        })
 
-    results.sort(key=lambda a : -a[4]) # sort by volume
+    results.sort(key=lambda a : -a['24h_volume']) # sort by volume
     return results
 
 
@@ -555,13 +553,13 @@ def get_top_markets():
 
 
 def get_top_smartcoins():
-    smartcoins = [[a[1], a[4]] for a in get_assets() if a[6] == 'SmartCoin']
+    smartcoins = [[a['asset_name'], a['24h_volume']] for a in get_assets() if a['asset_type'] == 'SmartCoin']
     return smartcoins[:7]
 
 
 @cache.memoize()
 def get_top_uias():
-    uias = [[a[1], a[4]] for a in get_assets() if a[6] == 'User Issued']
+    uias = [[a['asset_name'], a['24h_volume']] for a in get_assets() if a['asset_type'] == 'User Issued']
     return uias[:7]
 
 
@@ -613,13 +611,13 @@ def get_dex_total_volume():
     usd_price = 0
     cny_price = 0
     for a in get_assets():
-        if a[2] != config.CORE_ASSET_ID:
-            volume += a[4]
-        if a[1] == 'USD':
-            usd_price = a[3]
-        if a[1] == 'CNY':
-            cny_price = a[3]
-        market_cap += a[5]
+        if a['asset_id'] != config.CORE_ASSET_ID:
+            volume += a['24h_volume']
+        if a['asset_name'] == 'USD':
+            usd_price = a['latest_price']
+        if a['asset_name'] == 'CNY':
+            cny_price = a['latest_price']
+        market_cap += a['market_cap']
 
     res = {
         "volume_bts": round(volume), 

--- a/api/explorer.py
+++ b/api/explorer.py
@@ -602,7 +602,7 @@ def get_account_history(account_id, page):
             "block_num": op["block_data"]["block_num"],
             "id": op["account_history"]["operation_id"],
             "op_in_trx": op["operation_history"]["op_in_trx"],
-            "result": op["operation_history"]["operation_result"],
+            "result": json.loads(op["operation_history"]["operation_result"]),
             "timestamp": op["block_data"]["block_time"],
             "trx_in_block": op["operation_history"]["trx_in_block"],
             "virtual_op": op["operation_history"]["virtual_op"]

--- a/api/explorer.py
+++ b/api/explorer.py
@@ -497,7 +497,11 @@ def get_witnesses_votes():
         witness_account_name = witness[0]["witness_account_name"]
         proxy_votes = _get_formatted_proxy_votes(proxies, vote_id)        
 
-        witnesses_votes.append([witness_account_name, id_witness] + proxy_votes)
+        witnesses_votes.append({
+            'witness_account_name': witness_account_name, 
+            'witness_id': id_witness,
+            'top_proxy_votes': proxy_votes
+        })
 
     return witnesses_votes
 

--- a/api/explorer.py
+++ b/api/explorer.py
@@ -279,14 +279,13 @@ def get_most_active_markets():
         quote_asset = get_asset(m['quote'])
         ticker = get_ticker(m['base'], m['quote'])
         latest_price = float(ticker['latest'])
-        results.append([
-            0, # db_id
-            '{}/{}'.format(quote_asset['symbol'], base_asset['symbol']), # pair
-            0, # quote_asset_db_id
-            latest_price, # price
-            m['volume'] / 10**quote_asset['precision'], # volume
-            m['quote'] # quote_id
-        ])   
+        results.append({
+            'pair':  '{}/{}'.format(quote_asset['symbol'], base_asset['symbol']),
+            'latest_price': latest_price,
+            '24h_volume': m['volume'] / 10**quote_asset['precision'],
+            'quote_id': m['quote'],
+            'base_id': m['base']
+        })   
     
     return results
 
@@ -550,9 +549,9 @@ def get_committee_votes():
 
 def get_top_markets():
     markets = get_most_active_markets()
-    markets.sort(key=lambda a : -a[4]) # sort by volume
+    markets.sort(key=lambda a : -a['24h_volume']) # sort by volume
     top = markets[:7]
-    return [ [m[1], m[4]] for m in top ]
+    return [ [m['pair'], m['24h_volume']] for m in top ]
 
 
 def get_top_smartcoins():

--- a/api/explorer.py
+++ b/api/explorer.py
@@ -547,7 +547,11 @@ def get_committee_votes():
         committee_account_name = committee_member[0]["committee_member_account_name"]
         proxy_votes = _get_formatted_proxy_votes(proxies, vote_id)        
 
-        committee_votes.append([committee_account_name, id_committee] + proxy_votes)
+        committee_votes.append({ 
+            'committee_account_name': committee_account_name, 
+            'committee_id': id_committee,
+            'top_proxy_votes': proxy_votes
+        })
 
     return committee_votes
 

--- a/api/explorer.py
+++ b/api/explorer.py
@@ -75,7 +75,7 @@ def get_operation(operation_id):
     }
 
     operation = _enrich_operation(operation, bitshares_ws_client)
-    return [ operation ]
+    return operation
 
 def get_accounts():
     core_asset_holders = get_asset_holders('1.3.0', start=0, limit=100)

--- a/api/explorer.py
+++ b/api/explorer.py
@@ -238,14 +238,13 @@ def _get_markets(asset_id):
             quote_asset = get_asset(quote_id)
             ticker = get_ticker(base_id, quote_id)
             latest_price = float(ticker['latest'])
-            results.append([
-                0, # db_id
-                '{}/{}'.format(quote_asset['symbol'], base_asset['symbol']), # pair
-                0, # quote_asset_db_id
-                latest_price, # price
-                data['volume'] / 10**quote_asset['precision'], # volume
-                quote_id # quote_id
-            ])
+            results.append({
+                'pair': '{}/{}'.format(quote_asset['symbol'], base_asset['symbol']),
+                'latest_price': latest_price,
+                '24h_volume': data['volume'] / 10**quote_asset['precision'],
+                'quote_id': quote_id,
+                'base_id': base_id
+            })
 
     return results
 

--- a/api/explorer.py
+++ b/api/explorer.py
@@ -693,15 +693,14 @@ def get_all_referrers(account_id, page=0):
     
     results = []
     for account in accounts:
-        results.append([
-            0, # db_id
-            account['id'],                                  # account_id
-            account['name'],                                # account name
-            account['referrer'],                            # referrer id
-            account['referrer_rewards_percentage'],         # % of reward that goes to referrer
-            account['lifetime_referrer'],                   # lifetime referrer id
-            account['lifetime_referrer_fee_percentage']     #  % of reward that goes to lifetime referrer
-        ])
+        results.append({
+            'account_id': account['id'],
+            'account_name': account['name'],
+            'referrer': account['referrer'],
+            'referrer_rewards_percentage': account['referrer_rewards_percentage'], # % of reward that goes to referrer
+            'lifetime_referrer': account['lifetime_referrer'],
+            'lifetime_referrer_fee_percentage': account['lifetime_referrer_fee_percentage'] #  % of reward that goes to lifetime referrer
+        })
 
     return results
 

--- a/api/explorer.py
+++ b/api/explorer.py
@@ -522,7 +522,12 @@ def get_workers_votes():
         worker_name = worker[0]["name"]
         proxy_votes = _get_formatted_proxy_votes(proxies, vote_id)        
 
-        workers_votes.append([worker_account_name, id_worker, worker_name] + proxy_votes)
+        workers_votes.append({
+            'worker_account_name': worker_account_name, 
+            'worker_id': id_worker, 
+            'worker_name': worker_name,
+            'top_proxy_votes': proxy_votes
+        })
 
     return workers_votes
 

--- a/api/udf.py
+++ b/api/udf.py
@@ -60,9 +60,9 @@ def _get_market_pairs():
     markets = bitshares_es_client.get_markets('now-1d', 'now')
     result = []
     for base_id, quotes in markets.items():
-        base = api.explorer._get_asset(base_id)['symbol']
+        base = api.explorer.get_asset(base_id)['symbol']
         for quote_id, _ in quotes.items():
-            quote = api.explorer._get_asset(quote_id)['symbol']
+            quote = api.explorer.get_asset(quote_id)['symbol']
             result.append((base, quote))
     return result
 

--- a/requirements/tests.pip
+++ b/requirements/tests.pip
@@ -3,3 +3,4 @@ requests
 json_delta
 swagger_parser
 spec-synthase
+tavern

--- a/services/bitshares_websocket_client.py
+++ b/services/bitshares_websocket_client.py
@@ -8,19 +8,23 @@ class RPCError(Exception):
 class BitsharesWebsocketClient():
     def __init__(self, websocket_url):
         self.url = websocket_url
-        self.ws = create_connection(websocket_url)
+        self._connect()
+
+    def _connect(self):
+        self.ws = create_connection(self.url)
         self.request_id = 1
         self.api_ids = {
             'database': 0,
             'login': 1
         }
+
     
     def request(self, api, method_name, params):
         try:
             return self._safe_request(api, method_name, params)
         except WebSocketConnectionClosedException:
             self.ws.close()
-            self.ws = create_connection(self.url)
+            self._connect()
             return self._safe_request(api, method_name, params)
 
     def _safe_request(self, api, method_name, params):

--- a/swagger/api.yaml
+++ b/swagger/api.yaml
@@ -2,7 +2,7 @@ swagger: '2.0'
 info:
   title: BitShares Explorer API
   description: Exposes BitShares calls needed to explore the blockchain
-  version: '1'
+  version: '2.0.0'
 schemes:
   - http
   - https

--- a/swagger/paths_es_wrapper.yaml
+++ b/swagger/paths_es_wrapper.yaml
@@ -1,5 +1,5 @@
 paths:
-  "/es_account_history":
+  "/es/account_history":
     get:
       description: Get all operations in history with pager, similar to bitshares node call but with fullter features like search by date, filter by operation and others.
       operationId: api.es_wrapper.get_account_history
@@ -66,7 +66,7 @@ paths:
       tags:
         - wrapper
 
-  "/single_operation":
+  "/es/single_operation":
     get:
       description: Get a single operation by the operation ID.
       operationId: api.es_wrapper.get_single_operation
@@ -85,7 +85,7 @@ paths:
       tags:
         - wrapper
 
-  "/is_alive":
+  "/es/is_alive":
     get:
       description: Queries the latest head block and gives synchronization status of the elastic search database
       operationId: api.es_wrapper.is_alive
@@ -97,7 +97,7 @@ paths:
       tags:
         - wrapper
 
-  "/trx":
+  "/es/trx":
     get:
       description: Get the operations inside a transaction hash.
       operationId: api.es_wrapper.get_trx

--- a/swagger/paths_es_wrapper.yaml
+++ b/swagger/paths_es_wrapper.yaml
@@ -1,5 +1,5 @@
 paths:
-  "/get_account_history":
+  "/es_account_history":
     get:
       description: Get all operations in history with pager, similar to bitshares node call but with fullter features like search by date, filter by operation and others.
       operationId: api.es_wrapper.get_account_history
@@ -66,7 +66,7 @@ paths:
       tags:
         - wrapper
 
-  "/get_single_operation":
+  "/single_operation":
     get:
       description: Get a single operation by the operation ID.
       operationId: api.es_wrapper.get_single_operation
@@ -97,7 +97,7 @@ paths:
       tags:
         - wrapper
 
-  "/get_trx":
+  "/trx":
     get:
       description: Get the operations inside a transaction hash.
       operationId: api.es_wrapper.get_trx

--- a/swagger/paths_explorer.yaml
+++ b/swagger/paths_explorer.yaml
@@ -150,7 +150,7 @@ paths:
         - api
         - account
         - operation
-  "/get_asset":
+  "/asset":
     get:
       description: Get all info about an asset
       operationId: api.explorer.get_asset
@@ -169,7 +169,7 @@ paths:
       tags:
         - api
         - asset
-  "/get_asset_and_volume":
+  "/asset_and_volume":
     get:
       description: Same as get_asset but with additional volume info.
       operationId: api.explorer.get_asset_and_volume
@@ -188,7 +188,7 @@ paths:
       tags:
         - api
         - asset
-  "/get_block":
+  "/block":
     get:
       description: Get full block data
       operationId: api.explorer.get_block
@@ -207,7 +207,7 @@ paths:
       tags:
         - api
         - block
-  "/get_ticker":
+  "/ticker":
     get:
       description: Get ticker data for a market
       operationId: api.explorer.get_ticker
@@ -232,7 +232,7 @@ paths:
       tags:
         - api
         - market
-  "/get_object":
+  "/object":
     get:
       description: Get object from ID
       operationId: api.explorer.get_object
@@ -251,7 +251,7 @@ paths:
       tags:
         - api
         - object
-  "/get_asset_holders_count":
+  "/asset_holders_count":
     get:
       description: Get a count of holders and asset haves.
       operationId: api.explorer.get_asset_holders_count
@@ -270,7 +270,7 @@ paths:
       tags:
         - api
         - asset
-  "/get_asset_holders":
+  "/asset_holders":
     get:
       description: Get asset holders for an asset.
       operationId: api.explorer.get_asset_holders
@@ -301,7 +301,7 @@ paths:
       tags:
         - api
         - asset
-  "/get_workers":
+  "/workers":
     get:
       description: Get all workers.
       operationId: api.explorer.get_workers
@@ -313,7 +313,7 @@ paths:
       tags:
         - api
         - worker
-  "/get_markets":
+  "/markets":
     get:
       description: Get all the active markets for an asset.
       operationId: api.explorer.get_markets
@@ -332,7 +332,7 @@ paths:
       tags:
         - api
         - market
-  "/get_most_active_markets":
+  "/most_active_markets":
     get:
       description: Get the most active 100 markets in the network.
       operationId: api.explorer.get_most_active_markets
@@ -344,7 +344,7 @@ paths:
       tags:
         - api
         - market
-  "/get_order_book":
+  "/order_book":
     get:
       description: Get the order book of a market.
       operationId: api.explorer.get_order_book
@@ -375,7 +375,7 @@ paths:
       tags:
         - api
         - market
-  "/get_margin_positions":
+  "/margin_positions":
     get:
       description: Get margin positions of an account.
       operationId: api.explorer.get_margin_positions
@@ -395,7 +395,7 @@ paths:
         - api
         - market
         - account
-  "/get_witnesses":
+  "/witnesses":
     get:
       description: Get all witnesses.
       operationId: api.explorer.get_witnesses
@@ -408,7 +408,7 @@ paths:
         - api
         - witness
         - governance
-  "/get_committee_members":
+  "/committee_members":
     get:
       description: Get all committee members.
       operationId: api.explorer.get_committee_members
@@ -609,7 +609,7 @@ paths:
       tags:
         - api
         - operation
-  "/get_dex_total_volume":
+  "/dex_total_volume":
     get:
       description: Get some total dex volume figures
       operationId: api.explorer.get_dex_total_volume
@@ -645,7 +645,7 @@ paths:
       tags:
         - api
         - utility
-  "/get_all_asset_holders":
+  "/all_asset_holders":
     get:
       description: Get all holders of an asset
       operationId: api.explorer.get_all_asset_holders
@@ -685,7 +685,7 @@ paths:
         - api
         - account
         - referrer
-  "/get_all_referrers":
+  "/all_referrers":
     get:
       description: Get referrers an account made
       operationId: api.explorer.get_all_referrers
@@ -711,7 +711,7 @@ paths:
         - api
         - account
         - referrer
-  "/get_grouped_limit_orders":
+  "/grouped_limit_orders":
     get:
       description: Get the grouped order for a market
       operationId: api.explorer.get_grouped_limit_orders

--- a/swagger/paths_explorer.yaml
+++ b/swagger/paths_explorer.yaml
@@ -597,7 +597,7 @@ paths:
       tags:
         - api
         - asset
-  "/getlastblocknumbher":
+  "/last_block_number":
     get:
       description: Get current block number
       operationId: api.explorer.get_last_block_number

--- a/swagger/paths_explorer.yaml
+++ b/swagger/paths_explorer.yaml
@@ -49,10 +49,10 @@ paths:
       tags:
         - api
         - account
-  "/operation_full_elastic":
+  "/operation":
     get:
       description: Get operation by ID
-      operationId: api.explorer.get_operation_full_elastic
+      operationId: api.explorer.get_operation
       parameters:
         - in: query
           name: operation_id

--- a/swagger/paths_explorer.yaml
+++ b/swagger/paths_explorer.yaml
@@ -123,10 +123,10 @@ paths:
       tags:
         - api
         - blockchain
-  "/account_history_pager_elastic":
+  "/account_history":
     get:
-      description: Get history of account by pages (deprecated, use /account_history)
-      operationId: api.explorer.get_account_history_pager_elastic
+      description: Get history of account by pages
+      operationId: api.explorer.get_account_history
       deprecated: true
       parameters:
         - in: query

--- a/swagger/paths_udf.yaml
+++ b/swagger/paths_udf.yaml
@@ -1,5 +1,5 @@
 paths:
-  "/config":
+  "/udf/config":
     get:
       description: Get bitshares chart data configuration
       operationId: api.udf.get_config
@@ -10,7 +10,7 @@ paths:
           description: Error processing parameters
       tags:
         - udf
-  "/symbols":
+  "/udf/symbols":
     get:
       description: Get information about an asset(symbol)
       operationId: api.udf.get_symbols
@@ -28,7 +28,7 @@ paths:
           description: Error processing parameters
       tags:
         - udf
-  "/search":
+  "/udf/search":
     get:
       description: Search for an asset(symbol)
       operationId: api.udf.search
@@ -64,7 +64,7 @@ paths:
           description: Error processing parameters
       tags:
         - udf
-  "/history":
+  "/udf/history":
     get:
       description: Get OHLC data for symbol
       operationId: api.udf.get_history
@@ -100,7 +100,7 @@ paths:
           description: Error processing parameters
       tags:
         - udf
-  "/time":
+  "/udf/time":
     get:
       description: Get last server time
       operationId: api.udf.get_time

--- a/tests/local_urls.yaml
+++ b/tests/local_urls.yaml
@@ -1,0 +1,6 @@
+---
+name: Common test information
+description: Login information for localhost development server
+
+variables:
+  host: http://localhost:5000

--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+tavern-global-cfg= tests/local_urls.yaml
+tavern-beta-new-traceback = True

--- a/tests/test_api_es_wrapper.tavern.yaml
+++ b/tests/test_api_es_wrapper.tavern.yaml
@@ -1,0 +1,77 @@
+---
+test_name: Retrieve /get_account_history
+stages:
+  - name: Make sure we have the right content
+    request:
+      url: "{host}/get_account_history"
+      method: GET
+      params:
+        account_id: 1.2.0
+        size: 2
+    response:
+      status_code: 200
+      body:
+        - &operation_description
+          account_history:
+            account: !anystr
+            id: !anystr
+            next: !anystr
+            operation_id: !anystr
+            sequence: !anyint
+          block_data:
+            block_num: !anyint
+            block_time: !anystr
+            trx_id: !anystr
+          operation_history:
+            op: !anystr
+            op_in_trx: !anyint
+            op_object: !anything
+            operation_result: !anystr
+            trx_in_block: !anyint
+            virtual_op: !anyint
+          operation_id_num: !anyint
+          operation_type: !anyint
+        - *operation_description
+---
+test_name: Retrieve /get_single_operation
+stages:
+  - name: Make sure we have the right content
+    request:
+      url: "{host}/get_single_operation"
+      method: GET
+      params:
+        operation_id: 1.11.0
+    response:
+      status_code: 200
+      body:
+        - *operation_description
+---
+test_name: Retrieve /is_alive
+stages:
+  - name: Make sure we have the right content
+    request:
+      url: "{host}/is_alive"
+      method: GET
+    response:
+      status_code: 200
+      body:
+        deltatime: !anyfloat
+        head_block_time: !anystr
+        head_block_timestamp: !anyfloat
+        server_time: !anystr
+        status: ok
+---
+test_name: Retrieve /get_trx
+stages:
+  - name: Make sure we have the right content
+    request:
+      url: "{host}/get_trx"
+      method: GET
+      params:
+        trx: 738be2bd22e2da31d587d281ea7ee9bd02b9dbf0
+        size: 2
+    response:
+      status_code: 200
+      body:
+        - *operation_description
+        - *operation_description

--- a/tests/test_api_es_wrapper.tavern.yaml
+++ b/tests/test_api_es_wrapper.tavern.yaml
@@ -1,9 +1,9 @@
 ---
-test_name: Retrieve /es_account_history
+test_name: Retrieve /es/account_history
 stages:
   - name: Make sure we have the right content
     request:
-      url: "{host}/es_account_history"
+      url: "{host}/es/account_history"
       method: GET
       params:
         account_id: 1.2.0
@@ -33,11 +33,11 @@ stages:
           operation_type: !anyint
         - *operation_description
 ---
-test_name: Retrieve /single_operation
+test_name: Retrieve /es/single_operation
 stages:
   - name: Make sure we have the right content
     request:
-      url: "{host}/single_operation"
+      url: "{host}/es/single_operation"
       method: GET
       params:
         operation_id: 1.11.0
@@ -46,11 +46,11 @@ stages:
       body:
         - *operation_description
 ---
-test_name: Retrieve /is_alive
+test_name: Retrieve /es/is_alive
 stages:
   - name: Make sure we have the right content
     request:
-      url: "{host}/is_alive"
+      url: "{host}/es/is_alive"
       method: GET
     response:
       status_code: 200
@@ -61,11 +61,11 @@ stages:
         server_time: !anystr
         status: ok
 ---
-test_name: Retrieve /trx
+test_name: Retrieve /es/trx
 stages:
   - name: Make sure we have the right content
     request:
-      url: "{host}/trx"
+      url: "{host}/es/trx"
       method: GET
       params:
         trx: 738be2bd22e2da31d587d281ea7ee9bd02b9dbf0

--- a/tests/test_api_es_wrapper.tavern.yaml
+++ b/tests/test_api_es_wrapper.tavern.yaml
@@ -43,8 +43,7 @@ stages:
         operation_id: 1.11.0
     response:
       status_code: 200
-      body:
-        - *operation_description
+      body: *operation_description
 ---
 test_name: Retrieve /es/is_alive
 stages:

--- a/tests/test_api_es_wrapper.tavern.yaml
+++ b/tests/test_api_es_wrapper.tavern.yaml
@@ -1,9 +1,9 @@
 ---
-test_name: Retrieve /get_account_history
+test_name: Retrieve /es_account_history
 stages:
   - name: Make sure we have the right content
     request:
-      url: "{host}/get_account_history"
+      url: "{host}/es_account_history"
       method: GET
       params:
         account_id: 1.2.0
@@ -33,11 +33,11 @@ stages:
           operation_type: !anyint
         - *operation_description
 ---
-test_name: Retrieve /get_single_operation
+test_name: Retrieve /single_operation
 stages:
   - name: Make sure we have the right content
     request:
-      url: "{host}/get_single_operation"
+      url: "{host}/single_operation"
       method: GET
       params:
         operation_id: 1.11.0
@@ -61,11 +61,11 @@ stages:
         server_time: !anystr
         status: ok
 ---
-test_name: Retrieve /get_trx
+test_name: Retrieve /trx
 stages:
   - name: Make sure we have the right content
     request:
-      url: "{host}/get_trx"
+      url: "{host}/trx"
       method: GET
       params:
         trx: 738be2bd22e2da31d587d281ea7ee9bd02b9dbf0

--- a/tests/test_api_explorer.tavern.yaml
+++ b/tests/test_api_explorer.tavern.yaml
@@ -194,11 +194,11 @@ stages:
               trx_in_block: !anyint
               virtual_op: !anyint            
 ---
-test_name: Retrieve /get_asset
+test_name: Retrieve /asset
 stages:
   - name: Make sure we have the right content
     request:
-      url: "{host}/get_asset"
+      url: "{host}/asset"
       method: GET
       params:
         asset_id: BTS
@@ -212,11 +212,11 @@ stages:
           symbol: !anystr
           options: !anything
 ---
-test_name: Retrieve /get_asset_and_volume
+test_name: Retrieve /asset_and_volume
 stages:
   - name: Make sure we have the right content
     request:
-      url: "{host}/get_asset_and_volume"
+      url: "{host}/asset_and_volume"
       method: GET
       params:
         asset_id: BTS
@@ -233,11 +233,11 @@ stages:
           mcap: !anyint
           volume: !anyint
 ---
-test_name: Retrieve /get_block
+test_name: Retrieve /block
 stages:
   - name: Make sure we have the right content
     request:
-      url: "{host}/get_block"
+      url: "{host}/block"
       method: GET
       params:
         block_num: 1
@@ -252,11 +252,11 @@ stages:
         witness: !anystr
         witness_signature: !anystr
 ---
-test_name: Retrieve /get_ticker
+test_name: Retrieve /ticker
 stages:
   - name: Make sure we have the right content
     request:
-      url: "{host}/get_ticker"
+      url: "{host}/ticker"
       method: GET
       params:
         base: USD
@@ -274,11 +274,11 @@ stages:
         quote_volume: !anystr
         time: !anystr
 ---
-test_name: Retrieve /get_object
+test_name: Retrieve /object
 stages:
   - name: Make sure we have the right content
     request:
-      url: "{host}/get_object"
+      url: "{host}/object"
       method: GET
       params:
         object: 1.3.0
@@ -291,11 +291,11 @@ stages:
           symbol: !anystr
           options: !anything
 ---
-test_name: Retrieve /get_asset_holders_count
+test_name: Retrieve /asset_holders_count
 stages:
   - name: Make sure we have the right content
     request:
-      url: "{host}/get_asset_holders_count"
+      url: "{host}/asset_holders_count"
       method: GET
       params:
         asset_id: BTS
@@ -307,11 +307,11 @@ stages:
           extra_kwargs:
             unique_value: !anyint
 ---
-test_name: Retrieve /get_asset_holders
+test_name: Retrieve /asset_holders
 stages:
   - name: Make sure we have the right content
     request:
-      url: "{host}/get_asset_holders"
+      url: "{host}/asset_holders"
       method: GET
       params:
         asset_id: BTS
@@ -328,11 +328,11 @@ stages:
               amount: !anystr
               name: !anystr
 ---
-test_name: Retrieve /get_workers
+test_name: Retrieve /workers
 stages:
   - name: Make sure we have the right content
     request:
-      url: "{host}/get_workers"
+      url: "{host}/workers"
       method: GET
     response:
       status_code: 200
@@ -355,11 +355,11 @@ stages:
                 work_end_date: !anystr
                 worker: !anything
 ---
-test_name: Retrieve /get_markets
+test_name: Retrieve /markets
 stages:
   - name: Make sure we have the right content
     request:
-      url: "{host}/get_markets"
+      url: "{host}/markets"
       method: GET
       params:
         asset_id: BTS
@@ -377,11 +377,11 @@ stages:
               - !anyfloat
               - !anystr
 ---
-test_name: Retrieve /get_order_book
+test_name: Retrieve /order_book
 stages:
   - name: Make sure we have the right content
     request:
-      url: "{host}/get_order_book"
+      url: "{host}/order_book"
       method: GET
       params:
         base: BTS
@@ -401,11 +401,11 @@ stages:
         base: BTS
         quote: CNY
 ---
-test_name: Retrieve /get_margin_positions
+test_name: Retrieve /margin_positions
 stages:
   - name: Make sure we have the right content
     request:
-      url: "{host}/get_margin_positions"
+      url: "{host}/margin_positions"
       method: GET
       params:
         account_id: 1.2.0
@@ -428,11 +428,11 @@ stages:
               debt: !anyint
               id: !anystr
 ---
-test_name: Retrieve /get_witnesses
+test_name: Retrieve /witnesses
 stages:
   - name: Make sure we have the right content
     request:
-      url: "{host}/get_witnesses"
+      url: "{host}/witnesses"
       method: GET
     response:
       status_code: 200
@@ -452,11 +452,11 @@ stages:
                 witness_account: !anystr
                 witness_account_name: !anystr
 ---
-test_name: Retrieve /get_committee_members
+test_name: Retrieve /committee_members
 stages:
   - name: Make sure we have the right content
     request:
-      url: "{host}/get_committee_members"
+      url: "{host}/committee_members"
       method: GET
     response:
       status_code: 200
@@ -721,11 +721,11 @@ stages:
           extra_kwargs:
             unique_value: !anyint
 ---
-test_name: Retrieve /get_dex_total_volume
+test_name: Retrieve /dex_total_volume
 stages:
   - name: Make sure we have the right content
     request:
-      url: "{host}/get_dex_total_volume"
+      url: "{host}/dex_total_volume"
       method: GET
     response:
       status_code: 200
@@ -765,11 +765,11 @@ stages:
           extra_kwargs:
             element_desc: !anyint
 ---
-test_name: Retrieve /get_all_asset_holders
+test_name: Retrieve /all_asset_holders
 stages:
   - name: Make sure we have the right content
     request:
-      url: "{host}/get_all_asset_holders"
+      url: "{host}/all_asset_holders"
       method: GET
       params:
         asset_id: USD
@@ -797,11 +797,11 @@ stages:
       body:
         - !anyint
 ---
-test_name: Retrieve /get_all_referrers
+test_name: Retrieve /all_referrers
 stages:
   - name: Make sure we have the right content
     request:
-      url: "{host}/get_all_referrers"
+      url: "{host}/all_referrers"
       method: GET
       params:
         account_id: 2.2.0
@@ -821,11 +821,11 @@ stages:
               - !anystr
               - !anyint
 ---
-test_name: Retrieve /get_grouped_limit_orders
+test_name: Retrieve /grouped_limit_orders
 stages:
   - name: Make sure we have the right content
     request:
-      url: "{host}/get_grouped_limit_orders"
+      url: "{host}/grouped_limit_orders"
       method: GET
       params:
         base: BTS

--- a/tests/test_api_explorer.tavern.yaml
+++ b/tests/test_api_explorer.tavern.yaml
@@ -536,11 +536,10 @@ stages:
           function: tests.util:validate_list_of
           extra_kwargs:
             element_desc: 
-              - 0
-              - !anystr
-              - !anystr
-              - !anyint
-              - !anystr
+              account_id: !anystr
+              account_name: !anystr
+              amount: !anyint
+              voting_account: !anystr
 ---
 test_name: Retrieve /witnesses_votes
 stages:

--- a/tests/test_api_explorer.tavern.yaml
+++ b/tests/test_api_explorer.tavern.yaml
@@ -141,7 +141,7 @@ stages:
         $ext:
           function: tests.util:validate_list_of
           extra_kwargs:
-            element_desc:
+            element_desc: &asset_description
               asset_name: !anystr
               asset_id: !anystr
               latest_price: !anything
@@ -663,9 +663,7 @@ stages:
         $ext:
           function: tests.util:validate_list_of
           extra_kwargs:
-            element_desc: 
-              - !anystr
-              - !anyfloat
+            element_desc: *asset_description
 ---
 test_name: Retrieve /top_uias
 stages:
@@ -679,9 +677,7 @@ stages:
         $ext:
           function: tests.util:validate_list_of
           extra_kwargs:
-            element_desc: 
-              - !anystr
-              - !anyfloat
+            element_desc: *asset_description
 ---
 test_name: Retrieve /lookup_accounts
 stages:

--- a/tests/test_api_explorer.tavern.yaml
+++ b/tests/test_api_explorer.tavern.yaml
@@ -62,7 +62,7 @@ test_name: Retrieve /operation
 stages:
   - name: Make sure we have the right content
     request:
-      url: "{host}/operation_full_elastic"
+      url: "{host}/operation"
       method: GET
       params:
         operation_id: 1.11.0

--- a/tests/test_api_explorer.tavern.yaml
+++ b/tests/test_api_explorer.tavern.yaml
@@ -581,19 +581,20 @@ stages:
           function: tests.util:validate_list_of
           extra_kwargs:
             element_desc: 
-              - !anystr
-              - !anystr
-              - !anystr
-              - !anystr
-              - !anystr
-              - !anystr
-              - !anystr
-              - !anystr
-              - !anystr
-              - !anystr
-              - !anystr
-              - !anystr
-              - !anystr
+              worker_account_name: !anystr
+              worker_id: !anystr
+              worker_name: !anystr
+              top_proxy_votes:
+                - !anystr
+                - !anystr
+                - !anystr
+                - !anystr
+                - !anystr
+                - !anystr
+                - !anystr
+                - !anystr
+                - !anystr
+                - !anystr
 ---
 test_name: Retrieve /committee_votes
 stages:

--- a/tests/test_api_explorer.tavern.yaml
+++ b/tests/test_api_explorer.tavern.yaml
@@ -367,13 +367,12 @@ stages:
         $ext:
           function: tests.util:validate_list_of
           extra_kwargs:
-            element_desc:
-              - 0
-              - !anystr
-              - 0
-              - !anyfloat
-              - !anyfloat
-              - !anystr
+            element_desc: &market_description
+              24h_volume: !anyfloat
+              latest_price: !anyfloat
+              pair: !anystr
+              base_id: !anystr
+              quote_id: !anystr
 ---
 test_name: Retrieve /order_book
 stages:
@@ -634,12 +633,7 @@ stages:
         $ext:
           function: tests.util:validate_list_of
           extra_kwargs:
-            element_desc: &market_description 
-              24h_volume: !anyfloat
-              latest_price: !anyfloat
-              pair: !anystr
-              base_id: !anystr
-              quote_id: !anystr
+            element_desc: *market_description 
 ---
 test_name: Retrieve /top_markets
 stages:

--- a/tests/test_api_explorer.tavern.yaml
+++ b/tests/test_api_explorer.tavern.yaml
@@ -1,0 +1,854 @@
+---
+test_name: Retrieve /header
+stages:
+  - name: Make sure we have the right content
+    request:
+      url: "{host}/header"
+      method: GET
+    response:
+      status_code: 200
+      body:
+        accounts_registered_this_interval: !anyint
+        bts_market_cap: !anyint
+        commitee_count: !anyint
+        current_aslot: !anyint
+        current_witness: !anystr
+        dynamic_flags: !anyint
+        head_block_id: !anystr
+        head_block_number: !anyint
+        id: !anystr
+        last_budget_time: !anystr
+        last_irreversible_block_num: !anyint
+        next_maintenance_time: !anystr
+        quote_volume: !anystr
+        recent_slots_filled: !anystr
+        recently_missed_count: !anyint
+        time: !anystr
+        witness_budget: !anyint
+        witness_count: !anyint
+---
+test_name: Retrieve /account
+stages:
+  - name: Make sure we have the right content
+    request:
+      url: "{host}/account"
+      method: GET
+      params:
+        account_id: 1.2.0
+    response:
+      status_code: 200
+      body:
+      - id: !anystr
+        name: !anystr
+        referrer: !anystr
+---
+test_name: Retrieve /account_name
+stages:
+  - name: Make sure we have the right content
+    request:
+      url: "{host}/account_name"
+      method: GET
+      params:
+        account_id: 1.2.0
+    response:
+      status_code: 200
+      body: 
+        $ext:
+          function: tests.util:validate_unique_value
+          extra_kwargs:
+            unique_value: committee-account
+---
+test_name: Retrieve /operation
+stages:
+  - name: Make sure we have the right content
+    request:
+      url: "{host}/operation_full_elastic"
+      method: GET
+      params:
+        operation_id: 1.11.0
+    response:
+      status_code: 200
+      body:
+      - accounts_registered_this_interval: !anyint
+        block_num: !anyint
+        block_time: !anystr
+        bts_market_cap: !anyint
+        commitee_count: !anyint
+        op:
+          balance_owner_key: !anystr
+          balance_to_claim: !anystr
+          deposit_to_account: !anystr
+          fee:
+            amount: !anyint
+            asset_id: !anystr
+          total_claimed:
+            amount: !anyint
+            asset_id: !anystr
+        op_in_trx: !anyint
+        op_type: !anyint
+        quote_volume: !anystr
+        result: !anything
+        trx_id: !anystr
+        trx_in_block: !anyint
+        virtual_op: !anyint
+        witness_count: !anyint
+---
+test_name: Retrieve /accounts
+stages:
+  - name: Make sure we have the right content
+    request:
+      url: "{host}/accounts"
+      method: GET
+    response:
+      status_code: 200
+      body:
+        $ext:
+          function: tests.util:validate_list_of
+          extra_kwargs:
+            element_desc:
+              account_id: !anystr
+              amount: !anystr
+              name: !anystr
+---
+test_name: Retrieve /full_account
+stages:
+  - name: Make sure we have the right content
+    request:
+      url: "{host}/full_account"
+      method: GET
+      params:
+        account_id: 1.2.0
+    response:
+      status_code: 200
+      body:
+        - 
+          - 1.2.0
+          - account:
+              active: !anything
+              id: !anystr
+              name: !anystr
+            assets: !anything
+            balances: !anything
+            statistics: !anything
+---
+test_name: Retrieve /assets
+stages:
+  - name: Make sure we have the right content
+    request:
+      url: "{host}/assets"
+      method: GET
+    response:
+      status_code: 200
+      body:
+        $ext:
+          function: tests.util:validate_list_of
+          extra_kwargs:
+            element_desc:
+              - null
+              - !anystr
+              - !anystr
+              - !anything
+              - !anyfloat
+              - !anything
+              - !anystr
+              - !anyint
+              - !anyint
+              - !anystr
+              - !anyint
+---
+test_name: Retrieve /fees
+stages:
+  - name: Make sure we have the right content
+    request:
+      url: "{host}/fees"
+      method: GET
+    response:
+      status_code: 200
+      body:
+        id: !anystr
+        active_committee_members: !anything
+        active_witnesses: !anything
+        parameters: !anything
+---
+test_name: Retrieve /account_history_pager_elastic
+stages:
+  - name: Make sure we have the right content
+    request:
+      url: "{host}/account_history_pager_elastic"
+      method: GET
+      params:
+        account_id: 1.2.0
+        page: 0
+    response:
+      status_code: 200
+      body:
+        $ext:
+          function: tests.util:validate_list_of
+          extra_kwargs:
+            element_desc:
+              block_num: !anyint
+              id: !anystr
+              op: !anything
+              op_in_trx: !anyint
+              op_type: !anyint
+              result: !anything
+              timestamp: !anystr
+              trx_in_block: !anyint
+              virtual_op: !anyint            
+---
+test_name: Retrieve /get_asset
+stages:
+  - name: Make sure we have the right content
+    request:
+      url: "{host}/get_asset"
+      method: GET
+      params:
+        asset_id: BTS
+    response:
+      status_code: 200
+      body:
+        - id: !anystr
+          issuer: !anystr
+          issuer_name: !anystr
+          precision: !anyint
+          symbol: !anystr
+          options: !anything
+---
+test_name: Retrieve /get_asset_and_volume
+stages:
+  - name: Make sure we have the right content
+    request:
+      url: "{host}/get_asset_and_volume"
+      method: GET
+      params:
+        asset_id: BTS
+    response:
+      status_code: 200
+      body:
+        - id: !anystr
+          issuer: !anystr
+          issuer_name: !anystr
+          precision: !anyint
+          symbol: !anystr
+          options: !anything
+          latest_price: !anyint
+          mcap: !anyint
+          volume: !anyint
+---
+test_name: Retrieve /get_block
+stages:
+  - name: Make sure we have the right content
+    request:
+      url: "{host}/get_block"
+      method: GET
+      params:
+        block_num: 1
+    response:
+      status_code: 200
+      body:
+        extensions: !anything
+        previous: !anystr
+        timestamp: !anystr
+        transaction_merkle_root: !anystr
+        transactions: !anything
+        witness: !anystr
+        witness_signature: !anystr
+---
+test_name: Retrieve /get_ticker
+stages:
+  - name: Make sure we have the right content
+    request:
+      url: "{host}/get_ticker"
+      method: GET
+      params:
+        base: USD
+        quote: CNY
+    response:
+      status_code: 200
+      body:
+        base: "USD"
+        base_volume: !anystr
+        highest_bid: !anystr
+        latest: !anystr
+        lowest_ask: !anystr
+        percent_change: !anystr
+        quote: "CNY"
+        quote_volume: !anystr
+        time: !anystr
+---
+test_name: Retrieve /get_object
+stages:
+  - name: Make sure we have the right content
+    request:
+      url: "{host}/get_object"
+      method: GET
+      params:
+        object: 1.3.0
+    response:
+      status_code: 200
+      body:
+        - id: !anystr
+          issuer: !anystr
+          precision: !anyint
+          symbol: !anystr
+          options: !anything
+---
+test_name: Retrieve /get_asset_holders_count
+stages:
+  - name: Make sure we have the right content
+    request:
+      url: "{host}/get_asset_holders_count"
+      method: GET
+      params:
+        asset_id: BTS
+    response:
+      status_code: 200
+      body:
+        $ext:
+          function: tests.util:validate_unique_value
+          extra_kwargs:
+            unique_value: !anyint
+---
+test_name: Retrieve /get_asset_holders
+stages:
+  - name: Make sure we have the right content
+    request:
+      url: "{host}/get_asset_holders"
+      method: GET
+      params:
+        asset_id: BTS
+        start: 0
+        limit: 20
+    response:
+      status_code: 200
+      body:
+        $ext:
+          function: tests.util:validate_list_of
+          extra_kwargs:
+            element_desc:
+              account_id: !anystr
+              amount: !anystr
+              name: !anystr
+---
+test_name: Retrieve /get_workers
+stages:
+  - name: Make sure we have the right content
+    request:
+      url: "{host}/get_workers"
+      method: GET
+    response:
+      status_code: 200
+      body:
+        $ext:
+          function: tests.util:validate_list_of
+          extra_kwargs:
+            element_desc:
+              - id: !anystr
+                name: !anystr
+                worker_account: !anystr
+                worker_account_name: !anystr
+                url: !anystr
+                vote_against: !anystr
+                vote_for: !anystr
+                perc: !anyint
+                total_votes_against: !anyint
+                total_votes_for: !anything
+                work_begin_date: !anystr
+                work_end_date: !anystr
+                worker: !anything
+---
+test_name: Retrieve /get_markets
+stages:
+  - name: Make sure we have the right content
+    request:
+      url: "{host}/get_markets"
+      method: GET
+      params:
+        asset_id: BTS
+    response:
+      status_code: 200
+      body:
+        $ext:
+          function: tests.util:validate_list_of
+          extra_kwargs:
+            element_desc:
+              - 0
+              - !anystr
+              - 0
+              - !anyfloat
+              - !anyfloat
+              - !anystr
+---
+test_name: Retrieve /get_order_book
+stages:
+  - name: Make sure we have the right content
+    request:
+      url: "{host}/get_order_book"
+      method: GET
+      params:
+        base: BTS
+        quote: CNY
+        limit: 1
+    response:
+      status_code: 200
+      body:
+        asks: 
+          - base: !anystr
+            price: !anystr
+            quote: !anystr
+        bids:
+          - base: !anystr
+            price: !anystr
+            quote: !anystr
+        base: BTS
+        quote: CNY
+---
+test_name: Retrieve /get_margin_positions
+stages:
+  - name: Make sure we have the right content
+    request:
+      url: "{host}/get_margin_positions"
+      method: GET
+      params:
+        account_id: 1.2.0
+    response:
+      status_code: 200
+      body:
+        $ext:
+          function: tests.util:validate_list_of
+          extra_kwargs:
+            element_desc:
+              borrower: !anystr
+              call_price:
+                base:
+                  amount: !anyint
+                  asset_id: !anystr
+                quote:
+                  amount: !anyint
+                  asset_id: !anystr
+              collateral: !anyint
+              debt: !anyint
+              id: !anystr
+---
+test_name: Retrieve /get_witnesses
+stages:
+  - name: Make sure we have the right content
+    request:
+      url: "{host}/get_witnesses"
+      method: GET
+    response:
+      status_code: 200
+      body:
+        $ext:
+          function: tests.util:validate_list_of
+          extra_kwargs:
+            element_desc:
+              - id: !anystr
+                last_aslot: !anyint
+                last_confirmed_block_num: !anyint
+                signing_key: !anystr
+                total_missed: !anyint
+                total_votes: !anything
+                url: !anystr
+                vote_id: !anystr
+                witness_account: !anystr
+                witness_account_name: !anystr
+---
+test_name: Retrieve /get_committee_members
+stages:
+  - name: Make sure we have the right content
+    request:
+      url: "{host}/get_committee_members"
+      method: GET
+    response:
+      status_code: 200
+      body:
+        $ext:
+          function: tests.util:validate_list_of
+          extra_kwargs:
+            element_desc:
+              - id: !anystr
+                vote_id: !anystr
+                url: !anystr
+                total_votes: !anything
+                committee_member_account: !anystr
+                committee_member_account_name: !anystr
+---
+test_name: Retrieve /market_chart_dates
+stages:
+  - name: Make sure we have the right content
+    request:
+      url: "{host}/market_chart_dates"
+      method: GET
+    response:
+      status_code: 200
+      body:
+        $ext:
+          function: tests.util:validate_list_of
+          extra_kwargs:
+            element_desc: !anystr
+---
+test_name: Retrieve /market_chart_data
+stages:
+  - name: Make sure we have the right content
+    request:
+      url: "{host}/market_chart_data"
+      method: GET
+      params:
+        base: BTS
+        quote: CNY
+    response:
+      status_code: 200
+      body:
+        $ext:
+          function: tests.util:validate_list_of
+          extra_kwargs:
+            element_desc: 
+              - !anyfloat
+              - !anyfloat
+              - !anyfloat
+              - !anyfloat
+---
+test_name: Retrieve /top_proxies
+stages:
+  - name: Make sure we have the right content
+    request:
+      url: "{host}/top_proxies"
+      method: GET
+    response:
+      status_code: 200
+      body:
+        $ext:
+          function: tests.util:validate_list_of
+          extra_kwargs:
+            element_desc: 
+              - !anystr
+              - !anystr
+              - !anyint
+              - !anyint
+              - !anyfloat
+---
+test_name: Retrieve /top_holders
+stages:
+  - name: Make sure we have the right content
+    request:
+      url: "{host}/top_holders"
+      method: GET
+    response:
+      status_code: 200
+      body:
+        $ext:
+          function: tests.util:validate_list_of
+          extra_kwargs:
+            element_desc: 
+              - 0
+              - !anystr
+              - !anystr
+              - !anyint
+              - !anystr
+---
+test_name: Retrieve /witnesses_votes
+stages:
+  - name: Make sure we have the right content
+    request:
+      url: "{host}/witnesses_votes"
+      method: GET
+    response:
+      status_code: 200
+      body:
+        $ext:
+          function: tests.util:validate_list_of
+          extra_kwargs:
+            element_desc: 
+              - !anystr
+              - !anystr
+              - !anystr
+              - !anystr
+              - !anystr
+              - !anystr
+              - !anystr
+              - !anystr
+              - !anystr
+              - !anystr
+              - !anystr
+              - !anystr
+---
+test_name: Retrieve /workers_votes
+stages:
+  - name: Make sure we have the right content
+    request:
+      url: "{host}/workers_votes"
+      method: GET
+    response:
+      status_code: 200
+      body:
+        $ext:
+          function: tests.util:validate_list_of
+          extra_kwargs:
+            element_desc: 
+              - !anystr
+              - !anystr
+              - !anystr
+              - !anystr
+              - !anystr
+              - !anystr
+              - !anystr
+              - !anystr
+              - !anystr
+              - !anystr
+              - !anystr
+              - !anystr
+              - !anystr
+---
+test_name: Retrieve /committee_votes
+stages:
+  - name: Make sure we have the right content
+    request:
+      url: "{host}/committee_votes"
+      method: GET
+    response:
+      status_code: 200
+      body:
+        $ext:
+          function: tests.util:validate_list_of
+          extra_kwargs:
+            element_desc: 
+              - !anystr
+              - !anystr
+              - !anystr
+              - !anystr
+              - !anystr
+              - !anystr
+              - !anystr
+              - !anystr
+              - !anystr
+              - !anystr
+              - !anystr
+              - !anystr
+---
+test_name: Retrieve /top_markets
+stages:
+  - name: Make sure we have the right content
+    request:
+      url: "{host}/top_markets"
+      method: GET
+    response:
+      status_code: 200
+      body:
+        $ext:
+          function: tests.util:validate_list_of
+          extra_kwargs:
+            element_desc: 
+              - !anystr
+              - !anyfloat
+---
+test_name: Retrieve /top_smartcoins
+stages:
+  - name: Make sure we have the right content
+    request:
+      url: "{host}/top_smartcoins"
+      method: GET
+    response:
+      status_code: 200
+      body:
+        $ext:
+          function: tests.util:validate_list_of
+          extra_kwargs:
+            element_desc: 
+              - !anystr
+              - !anyfloat
+---
+test_name: Retrieve /top_uias
+stages:
+  - name: Make sure we have the right content
+    request:
+      url: "{host}/top_uias"
+      method: GET
+    response:
+      status_code: 200
+      body:
+        $ext:
+          function: tests.util:validate_list_of
+          extra_kwargs:
+            element_desc: 
+              - !anystr
+              - !anyfloat
+---
+test_name: Retrieve /lookup_accounts
+stages:
+  - name: Make sure we have the right content
+    request:
+      url: "{host}/lookup_accounts"
+      method: GET
+      params:
+        start: A
+    response:
+      status_code: 200
+      body:
+        $ext:
+          function: tests.util:validate_list_of
+          extra_kwargs:
+            element_desc: 
+              - !anystr
+              - !anystr
+---
+test_name: Retrieve /lookup_assets
+stages:
+  - name: Make sure we have the right content
+    request:
+      url: "{host}/lookup_assets"
+      method: GET
+      params:
+        start: A
+    response:
+      status_code: 200
+      body:
+        $ext:
+          function: tests.util:validate_list_of
+          extra_kwargs:
+            element_desc: 
+              - !anystr
+---
+test_name: Retrieve /getlastblocknumbher
+stages:
+  - name: Make sure we have the right content
+    request:
+      url: "{host}/getlastblocknumbher"
+      method: GET
+    response:
+      status_code: 200
+      body:
+        $ext:
+          function: tests.util:validate_unique_value
+          extra_kwargs:
+            unique_value: !anyint
+---
+test_name: Retrieve /get_dex_total_volume
+stages:
+  - name: Make sure we have the right content
+    request:
+      url: "{host}/get_dex_total_volume"
+      method: GET
+    response:
+      status_code: 200
+      body:
+        market_cap_bts: !anyfloat
+        market_cap_cny: !anyfloat
+        market_cap_usd: !anyfloat
+        volume_bts: !anyfloat
+        volume_usd: !anyfloat
+        volume_cny: !anyfloat
+---
+test_name: Retrieve /daily_volume_dex_dates
+stages:
+  - name: Make sure we have the right content
+    request:
+      url: "{host}/daily_volume_dex_dates"
+      method: GET
+    response:
+      status_code: 200
+      body:
+        $ext:
+          function: tests.util:validate_list_of
+          extra_kwargs:
+            element_desc: !anystr
+---
+test_name: Retrieve /daily_volume_dex_data
+stages:
+  - name: Make sure we have the right content
+    request:
+      url: "{host}/daily_volume_dex_data"
+      method: GET
+    response:
+      status_code: 200
+      body:
+        $ext:
+          function: tests.util:validate_list_of
+          extra_kwargs:
+            element_desc: !anyint
+---
+test_name: Retrieve /get_all_asset_holders
+stages:
+  - name: Make sure we have the right content
+    request:
+      url: "{host}/get_all_asset_holders"
+      method: GET
+      params:
+        asset_id: USD
+    response:
+      status_code: 200
+      body:
+        $ext:
+          function: tests.util:validate_list_of
+          extra_kwargs:
+            element_desc:
+              account_id: !anystr
+              amount: !anything
+              name: !anystr
+---
+test_name: Retrieve /referrer_count
+stages:
+  - name: Make sure we have the right content
+    request:
+      url: "{host}/referrer_count"
+      method: GET
+      params:
+        account_id: 1.2.0
+    response:
+      status_code: 200
+      body:
+        - !anyint
+---
+test_name: Retrieve /get_all_referrers
+stages:
+  - name: Make sure we have the right content
+    request:
+      url: "{host}/get_all_referrers"
+      method: GET
+      params:
+        account_id: 2.2.0
+        page: 0
+    response:
+      status_code: 200
+      body:
+        $ext:
+          function: tests.util:validate_list_of
+          extra_kwargs:
+            element_desc:
+              - 0
+              - !anystr
+              - !anystr
+              - !anystr
+              - !anyint
+              - !anystr
+              - !anyint
+---
+test_name: Retrieve /get_grouped_limit_orders
+stages:
+  - name: Make sure we have the right content
+    request:
+      url: "{host}/get_grouped_limit_orders"
+      method: GET
+      params:
+        base: BTS
+        quote: CNY
+        group: 10
+        limit: 1
+    response:
+      status_code: 200
+      body:
+        - max_price:
+            base:
+              amount: !anything
+              asset_id: !anystr
+            quote:
+              amount: !anything
+              asset_id: !anystr
+          min_price:
+            base:
+              amount: !anything
+              asset_id: !anystr
+            quote:
+              amount: !anything
+              asset_id: !anystr
+          total_for_sale: !anything              

--- a/tests/test_api_explorer.tavern.yaml
+++ b/tests/test_api_explorer.tavern.yaml
@@ -636,7 +636,7 @@ stages:
         $ext:
           function: tests.util:validate_list_of
           extra_kwargs:
-            element_desc: 
+            element_desc: &market_description 
               24h_volume: !anyfloat
               latest_price: !anyfloat
               pair: !anystr
@@ -655,9 +655,7 @@ stages:
         $ext:
           function: tests.util:validate_list_of
           extra_kwargs:
-            element_desc: 
-              - !anystr
-              - !anyfloat
+            element_desc: *market_description
 ---
 test_name: Retrieve /top_smartcoins
 stages:

--- a/tests/test_api_explorer.tavern.yaml
+++ b/tests/test_api_explorer.tavern.yaml
@@ -438,16 +438,16 @@ stages:
           function: tests.util:validate_list_of
           extra_kwargs:
             element_desc:
-              - id: !anystr
-                last_aslot: !anyint
-                last_confirmed_block_num: !anyint
-                signing_key: !anystr
-                total_missed: !anyint
-                total_votes: !anything
-                url: !anystr
-                vote_id: !anystr
-                witness_account: !anystr
-                witness_account_name: !anystr
+              id: !anystr
+              last_aslot: !anyint
+              last_confirmed_block_num: !anyint
+              signing_key: !anystr
+              total_missed: !anyint
+              total_votes: !anything
+              url: !anystr
+              vote_id: !anystr
+              witness_account: !anystr
+              witness_account_name: !anystr
 ---
 test_name: Retrieve /committee_members
 stages:

--- a/tests/test_api_explorer.tavern.yaml
+++ b/tests/test_api_explorer.tavern.yaml
@@ -802,7 +802,10 @@ stages:
     response:
       status_code: 200
       body:
-        - !anyint
+        $ext:
+          function: tests.util:validate_unique_value
+          extra_kwargs:
+            unique_value: !anyint
 ---
 test_name: Retrieve /all_referrers
 stages:

--- a/tests/test_api_explorer.tavern.yaml
+++ b/tests/test_api_explorer.tavern.yaml
@@ -142,17 +142,15 @@ stages:
           function: tests.util:validate_list_of
           extra_kwargs:
             element_desc:
-              - null
-              - !anystr
-              - !anystr
-              - !anything
-              - !anyfloat
-              - !anything
-              - !anystr
-              - !anyint
-              - !anyint
-              - !anystr
-              - !anyint
+              asset_name: !anystr
+              asset_id: !anystr
+              latest_price: !anything
+              24h_volume: !anyfloat
+              market_cap: !anything
+              asset_type: !anystr
+              current_supply: !anyint
+              holders_count: !anyint
+              precision: !anyint
 ---
 test_name: Retrieve /fees
 stages:

--- a/tests/test_api_explorer.tavern.yaml
+++ b/tests/test_api_explorer.tavern.yaml
@@ -609,18 +609,19 @@ stages:
           function: tests.util:validate_list_of
           extra_kwargs:
             element_desc: 
-              - !anystr
-              - !anystr
-              - !anystr
-              - !anystr
-              - !anystr
-              - !anystr
-              - !anystr
-              - !anystr
-              - !anystr
-              - !anystr
-              - !anystr
-              - !anystr
+              committee_account_name: !anystr
+              committee_id: !anystr
+              top_proxy_votes:
+                - !anystr
+                - !anystr
+                - !anystr
+                - !anystr
+                - !anystr
+                - !anystr
+                - !anystr
+                - !anystr
+                - !anystr
+                - !anystr
 ---
 test_name: Retrieve /most_active_markets
 stages:

--- a/tests/test_api_explorer.tavern.yaml
+++ b/tests/test_api_explorer.tavern.yaml
@@ -69,7 +69,7 @@ stages:
     response:
       status_code: 200
       body:
-      - accounts_registered_this_interval: !anyint
+        accounts_registered_this_interval: !anyint
         block_num: !anyint
         block_time: !anystr
         bts_market_cap: !anyint

--- a/tests/test_api_explorer.tavern.yaml
+++ b/tests/test_api_explorer.tavern.yaml
@@ -520,11 +520,11 @@ stages:
           function: tests.util:validate_list_of
           extra_kwargs:
             element_desc: 
-              - !anystr
-              - !anystr
-              - !anyint
-              - !anyint
-              - !anyfloat
+              id: !anystr
+              name: !anystr
+              bts_weight: !anyint
+              followers: !anyint
+              bts_weight_percentage: !anyfloat
 ---
 test_name: Retrieve /top_holders
 stages:

--- a/tests/test_api_explorer.tavern.yaml
+++ b/tests/test_api_explorer.tavern.yaml
@@ -624,6 +624,25 @@ stages:
               - !anystr
               - !anystr
 ---
+test_name: Retrieve /most_active_markets
+stages:
+  - name: Make sure we have the right content
+    request:
+      url: "{host}/most_active_markets"
+      method: GET
+    response:
+      status_code: 200
+      body:
+        $ext:
+          function: tests.util:validate_list_of
+          extra_kwargs:
+            element_desc: 
+              24h_volume: !anyfloat
+              latest_price: !anyfloat
+              pair: !anystr
+              base_id: !anystr
+              quote_id: !anystr
+---
 test_name: Retrieve /top_markets
 stages:
   - name: Make sure we have the right content

--- a/tests/test_api_explorer.tavern.yaml
+++ b/tests/test_api_explorer.tavern.yaml
@@ -205,12 +205,12 @@ stages:
     response:
       status_code: 200
       body:
-        - id: !anystr
-          issuer: !anystr
-          issuer_name: !anystr
-          precision: !anyint
-          symbol: !anystr
-          options: !anything
+        id: !anystr
+        issuer: !anystr
+        issuer_name: !anystr
+        precision: !anyint
+        symbol: !anystr
+        options: !anything
 ---
 test_name: Retrieve /asset_and_volume
 stages:
@@ -223,15 +223,15 @@ stages:
     response:
       status_code: 200
       body:
-        - id: !anystr
-          issuer: !anystr
-          issuer_name: !anystr
-          precision: !anyint
-          symbol: !anystr
-          options: !anything
-          latest_price: !anyint
-          mcap: !anyint
-          volume: !anyint
+        id: !anystr
+        issuer: !anystr
+        issuer_name: !anystr
+        precision: !anyint
+        symbol: !anystr
+        options: !anything
+        latest_price: !anyint
+        mcap: !anyint
+        volume: !anyint
 ---
 test_name: Retrieve /block
 stages:

--- a/tests/test_api_explorer.tavern.yaml
+++ b/tests/test_api_explorer.tavern.yaml
@@ -285,11 +285,11 @@ stages:
     response:
       status_code: 200
       body:
-        - id: !anystr
-          issuer: !anystr
-          precision: !anyint
-          symbol: !anystr
-          options: !anything
+        id: !anystr
+        issuer: !anystr
+        precision: !anyint
+        symbol: !anystr
+        options: !anything
 ---
 test_name: Retrieve /asset_holders_count
 stages:

--- a/tests/test_api_explorer.tavern.yaml
+++ b/tests/test_api_explorer.tavern.yaml
@@ -38,7 +38,7 @@ stages:
     response:
       status_code: 200
       body:
-      - id: !anystr
+        id: !anystr
         name: !anystr
         referrer: !anystr
 ---
@@ -121,15 +121,13 @@ stages:
     response:
       status_code: 200
       body:
-        - 
-          - 1.2.0
-          - account:
-              active: !anything
-              id: !anystr
-              name: !anystr
-            assets: !anything
-            balances: !anything
-            statistics: !anything
+        account:
+          active: !anything
+          id: !anystr
+          name: !anystr
+        assets: !anything
+        balances: !anything
+        statistics: !anything
 ---
 test_name: Retrieve /assets
 stages:

--- a/tests/test_api_explorer.tavern.yaml
+++ b/tests/test_api_explorer.tavern.yaml
@@ -707,11 +707,11 @@ stages:
             element_desc: 
               - !anystr
 ---
-test_name: Retrieve /getlastblocknumbher
+test_name: Retrieve /last_block_number
 stages:
   - name: Make sure we have the right content
     request:
-      url: "{host}/getlastblocknumbher"
+      url: "{host}/last_block_number"
       method: GET
     response:
       status_code: 200

--- a/tests/test_api_explorer.tavern.yaml
+++ b/tests/test_api_explorer.tavern.yaml
@@ -554,18 +554,19 @@ stages:
           function: tests.util:validate_list_of
           extra_kwargs:
             element_desc: 
-              - !anystr
-              - !anystr
-              - !anystr
-              - !anystr
-              - !anystr
-              - !anystr
-              - !anystr
-              - !anystr
-              - !anystr
-              - !anystr
-              - !anystr
-              - !anystr
+              witness_account_name: !anystr
+              witness_id: !anystr
+              top_proxy_votes:
+                - !anystr
+                - !anystr
+                - !anystr
+                - !anystr
+                - !anystr
+                - !anystr
+                - !anystr
+                - !anystr
+                - !anystr
+                - !anystr
 ---
 test_name: Retrieve /workers_votes
 stages:

--- a/tests/test_api_explorer.tavern.yaml
+++ b/tests/test_api_explorer.tavern.yaml
@@ -820,13 +820,12 @@ stages:
           function: tests.util:validate_list_of
           extra_kwargs:
             element_desc:
-              - 0
-              - !anystr
-              - !anystr
-              - !anystr
-              - !anyint
-              - !anystr
-              - !anyint
+              account_id: !anystr
+              account_name: !anystr
+              referrer: !anystr
+              referrer_rewards_percentage: !anyint
+              lifetime_referrer: !anystr
+              lifetime_referrer_fee_percentage: !anyint
 ---
 test_name: Retrieve /grouped_limit_orders
 stages:

--- a/tests/test_api_explorer.tavern.yaml
+++ b/tests/test_api_explorer.tavern.yaml
@@ -170,11 +170,11 @@ stages:
         active_witnesses: !anything
         parameters: !anything
 ---
-test_name: Retrieve /account_history_pager_elastic
+test_name: Retrieve /account_history
 stages:
   - name: Make sure we have the right content
     request:
-      url: "{host}/account_history_pager_elastic"
+      url: "{host}/account_history"
       method: GET
       params:
         account_id: 1.2.0

--- a/tests/test_api_udf.tavern.yaml
+++ b/tests/test_api_udf.tavern.yaml
@@ -1,9 +1,9 @@
 ---
-test_name: Retrieve /config
+test_name: Retrieve /udf/config
 stages:
   - name: Make sure we have the right content
     request:
-      url: "{host}/config"
+      url: "{host}/udf/config"
       method: GET
     response:
       status_code: 200
@@ -21,11 +21,11 @@ stages:
         supports_search: true
         supports_time: true
 ---
-test_name: Retrieve /symbols
+test_name: Retrieve /udf/symbols
 stages:
   - name: Make sure we have the right content
     request:
-      url: "{host}/symbols"
+      url: "{host}/udf/symbols"
       method: GET
       params:
         symbol: USD_CNY
@@ -69,11 +69,11 @@ stages:
         type: ''
         volume_precision: ''
 ---
-test_name: Retrieve /search
+test_name: Retrieve /udf/search
 stages:
   - name: Make sure we have the right content
     request:
-      url: "{host}/search"
+      url: "{host}/udf/search"
       method: GET
       params:
         query: USD
@@ -91,11 +91,11 @@ stages:
               ticker: !anystr
               type: !anystr
 ---
-test_name: Retrieve /history
+test_name: Retrieve /udf/history
 stages:
   - name: Make sure we have the right content
     request:
-      url: "{host}/history"
+      url: "{host}/udf/history"
       method: GET
       params:
         symbol: USD_CNY
@@ -173,11 +173,11 @@ stages:
           - !anyint
           - !anyint
 ---
-test_name: Retrieve /time
+test_name: Retrieve /udf/time
 stages:
   - name: Make sure we have the right content
     request:
-      url: "{host}/time"
+      url: "{host}/udf/time"
       method: GET
     response:
       status_code: 200

--- a/tests/test_api_udf.tavern.yaml
+++ b/tests/test_api_udf.tavern.yaml
@@ -1,0 +1,188 @@
+---
+test_name: Retrieve /config
+stages:
+  - name: Make sure we have the right content
+    request:
+      url: "{host}/config"
+      method: GET
+    response:
+      status_code: 200
+      body:
+        supported_resolutions:
+            - '1'
+            - '5'
+            - '15'
+            - '30'
+            - '60'
+            - '240'
+            - 1D
+        supports_group_request: false
+        supports_marks: false
+        supports_search: true
+        supports_time: true
+---
+test_name: Retrieve /symbols
+stages:
+  - name: Make sure we have the right content
+    request:
+      url: "{host}/symbols"
+      method: GET
+      params:
+        symbol: USD_CNY
+    response:
+      status_code: 200
+      body:
+        currency_code: ''
+        data_status: ''
+        description: USD/CNY
+        exchange: ''
+        expiration_date: ''
+        expired: ''
+        force_session_rebuild: ''
+        fractional: false
+        has_daily: true
+        has_empty_bars: true
+        has_intraday: true
+        has_no_volume: false
+        has_seconds: false
+        has_weekly_and_monthly: false
+        industry: ''
+        intraday_multipliers: ''
+        listed_exchange: ''
+        minmov: 1
+        minmove2: 0
+        name: USD_CNY
+        pricescale: 10000
+        seconds_multipliers: ''
+        sector: ''
+        session: 24x7
+        supported_resolutions:
+            - '1'
+            - '5'
+            - '15'
+            - '30'
+            - '60'
+            - '240'
+            - 1D
+        ticker: USD_CNY
+        timezone: Europe/London
+        type: ''
+        volume_precision: ''
+---
+test_name: Retrieve /search
+stages:
+  - name: Make sure we have the right content
+    request:
+      url: "{host}/search"
+      method: GET
+      params:
+        query: USD
+    response:
+      status_code: 200
+      body:
+        $ext:
+          function: tests.util:validate_list_of
+          extra_kwargs:
+            element_desc:
+              description: !anystr
+              exchange: !anystr
+              full_name: !anystr
+              symbol: !anystr
+              ticker: !anystr
+              type: !anystr
+---
+test_name: Retrieve /history
+stages:
+  - name: Make sure we have the right content
+    request:
+      url: "{host}/history"
+      method: GET
+      params:
+        symbol: USD_CNY
+        from: 1513092731
+        to: 1513956731
+        resolution: D
+    response:
+      status_code: 200
+      body:
+        c:
+          - !anyfloat
+          - !anyfloat
+          - !anyfloat
+          - !anyfloat
+          - !anyfloat
+          - !anyfloat
+          - !anyfloat
+          - !anyfloat
+          - !anyfloat
+          - !anyfloat
+        h:
+          - !anyfloat
+          - !anyfloat
+          - !anyfloat
+          - !anyfloat
+          - !anyfloat
+          - !anyfloat
+          - !anyfloat
+          - !anyfloat
+          - !anyfloat
+          - !anyfloat
+        l:
+          - !anyfloat
+          - !anyfloat
+          - !anyfloat
+          - !anyfloat
+          - !anyfloat
+          - !anyfloat
+          - !anyfloat
+          - !anyfloat
+          - !anyfloat
+          - !anyfloat
+        o:
+          - !anyfloat
+          - !anyfloat
+          - !anyfloat
+          - !anyfloat
+          - !anyfloat
+          - !anyfloat
+          - !anyfloat
+          - !anyfloat
+          - !anyfloat
+          - !anyfloat
+        s: ok
+        t:
+          - !anyint
+          - !anyint
+          - !anyint
+          - !anyint
+          - !anyint
+          - !anyint
+          - !anyint
+          - !anyint
+          - !anyint
+          - !anyint
+        v:
+          - !anyint
+          - !anyint
+          - !anyint
+          - !anyint
+          - !anyint
+          - !anyint
+          - !anyint
+          - !anyint
+          - !anyint
+          - !anyint
+---
+test_name: Retrieve /time
+stages:
+  - name: Make sure we have the right content
+    request:
+      url: "{host}/time"
+      method: GET
+    response:
+      status_code: 200
+      body:
+        $ext:
+          function: tests.util:validate_unique_value
+          extra_kwargs:
+            unique_value: !anystr

--- a/tests/util.py
+++ b/tests/util.py
@@ -1,0 +1,11 @@
+from tavern.util.dict_util import check_keys_match_recursive
+
+def validate_unique_value(response, unique_value):
+    check_keys_match_recursive(unique_value, response.json(), [], strict=False)
+
+def validate_list_of(response, element_desc):
+    elements = response.json()
+    assert type(elements) == list
+    for e in elements:
+        check_keys_match_recursive(element_desc, e, [], strict=False)
+


### PR DESCRIPTION
Make changes proposed in #33.

These are breaking changes, client application needs to be upgraded (especialy open-explorer web site).

Based on top of #44 (to be merged first).

Summary of all changes:

- Renamed `/operation_full_elastic` in `/operation`.
- Renamed `/account_history_pager_elastic` in `/account_history`.
- `/operation` return a single element instead of a list.
- `/account` and `/full_account` return a single element instead of a list.
- Removed `get_` prefix from the all paths. 
  - Renamed `/get_asset` to `/asset`;
  - Renamed `/get_asset_and_volume` to `/asset_and_volume`;
  - Renamed `/get_block` to `/block`;
  - Renamed `/get_ticker` to `/ticker`;
  - Renamed `/get_object` to `/object`;
  - Renamed `/get_asset_holders_count` to `/asset_holders_count`;
  - Renamed `/get_asset_holders` to `/asset_holders`;
  - Renamed `/get_workers` to `/workers`;
  - Renamed `/get_markets` to `/markets`;
  - Renamed `/get_most_active_markets` to `/most_active_markets`;
  - Renamed `/get_order_book` to `/order_book`;
  - Renamed `/get_margin_positions` to `/margin_positions`;
  - Renamed `/get_witnesses` to `/witnesses`;
  - Renamed `/get_committee_members` to `/committee_members`;
  - Renamed `/get_dex_total_volume` to `/dex_total_volume`;
  - Renamed `/get_all_asset_holders` to `/all_asset_holders`;
  - Renamed `/get_all_referrers` to `/all_referrers`;
  - Renamed `/get_grouped_limit_orders` to `/grouped_limit_orders`;
  - Renamed `/get_account_history` (in es wrapper) to `/account_history`;
  - Renamed `/get_single_operation` (in es wrapper) to `/single_operation`;
  - Renamed `/get_trx` (in es wrapper) to `/trx`.
- Prefix all ES wrapper paths with `/es`.
  - Renamed `/account_history` (in es wrapper) to `/es/account_history`;
  - Renamed `/single_operation` (in es wrapper) to `/es/single_operation`;
  - Renamed `/trx` (in es wrapper) to `/es/trx`;
  - Renamed `/is_alive` (in es wrapper) to `/es/is_alive`.
- Prefix all UDF paths with `/udf`.
  - Renamed `/config` (in udf) to `/udf/config`;
  - Renamed `/symbols` (in udf) to `/udf/symbols`;
  - Renamed `/search` (in udf) to `/udf/search`;
  - Renamed `/history` (in udf) to `/udf/history`;
  - Renamed `/time` (in udf) to `/udf/time`.
- `/asset` and `/asset_and_volume` return a single element instead of a list.
- `/object` return a single element instead of a list.
- Renamed `/getlastblocknumbher` to `/last_block_number`.
- Return objects with named fields instead of arrays for `/top_proxies`.
    - index 0 -> id
    - index 1 -> name
    - index 2 -> bts_weight
    - index 3 -> followers
    - index 4 -> bts_weight_percentage
- Return objects with named fields instead of arrays for `/most_active_markets`.
    - index 0 -> field deleted (db_id)
    - index 1 -> pair
    - index 2 -> field deleted (quote_asset_db_id)
    - index 3 -> latest_price
    - index 4 -> 24h_volume
    - index 5 -> quote_id
    - Add base_id in response.
- Return objects with named fields instead of arrays for `/top_markets`.
    - index 0 -> pair
    - index 1 -> 24h_volume
    - Align fields with `/most_active_markets`.
- Return objects with named fields instead of arrays for `/assets`.
    - index 0 -> field deleted (db id) 
    - index 1 -> asset_name
    - index 2 -> asset_id
    - index 3 -> latest_price
    - index 4 -> 24h_volume
    - index 5 -> market_cap
    - index 6 -> asset_type
    - index 7 -> current_supply
    - index 8 -> holders_count
    - index 9 -> field deleted (wallet type)
    - index 20 -> precision
- Return objects with named fields instead of arrays for `/markets`.
    - index 0 -> field deleted (db id)
    - index 1 -> pair
    - index 2 -> field deleted (quote_asset_db_id)
    - index 3 -> latest_price
    - index 4 -> 24h_volume
    - index 5 -> quote_id
    - Add base_id in response.
    - Align fields with `/most_active_markets`
- Return objects with named fields instead of arrays for `/top_holders`.
    - index 0 -> field deleted (db id)
    - index 1 -> account_id
    - index 2 -> account_name
    - index 3 -> amount
    - index 4 -> voting_account
- Return objects with named fields instead of arrays for `/witnesses_votes`.
    - index 0 -> witness_account_name
    - index 1 -> witness_id
    - index 2 to 12 -> top_proxy_votes
- Return objects with named fields instead of arrays for `/workers_votes`.
    - index 0 -> worker_account_name
    - index 1 -> worker_id
    - index 2 -> worker_name
    - index 3 to 13 -> top_proxy_votes
- Return objects with named fields instead of arrays for `/committee_votes`.
    - index 0 -> committee_account_name
    - index 1 -> committee_id
    - index 2 to 12 -> top_proxy_votes
- Return objects with named fields instead of arrays for `/top_uias` and `/top_smartcoins`.
    - index 0 -> asset_name
    - index 1 -> 24h_volume
    - Align fields with `/assets`
- Return objects with named fields instead of arrays for `/all_referrers`.
    - index 0 -> field deleted (db id)
    - index 1 -> account_id
    - index 2 -> account_name
    - index 3 -> referrer
    - index 4 -> referrer_rewards_percentage
    - index 5 -> lifetime_referrer
    - index 6 -> lifetime_referrer_fee_percentage
- `/referrer_count` return a single element instead of a list.
- `/witnesses` return a list of elements instead of a list of a list of one element.
- `/es/single_operation` return a single element instead of a list.
- Make `/account_history` coherent with `/operation` (following #28) in regards of result deserialization.