### PR TITLE
Fix acount_history deep search (#39)

### DIFF
--- a/api/es_wrapper.py
+++ b/api/es_wrapper.py
@@ -3,16 +3,16 @@ from services.bitshares_elasticsearch_client import es
 from elasticsearch.exceptions import NotFoundError
 from datetime import datetime, timedelta
 
-def get_account_history(account_id=None, operation_type=None, size=10, 
+def get_account_history(account_id=None, operation_type=None, from_=0, size=10, 
                         from_date='2015-10-10', to_date='now', sort_by='-operation_id_num',
                         search_after=None, type='data', agg_field='operation_type'):
     s = Search(using=es, index="bitshares-*")
     if type == "data":
         s = s.extra(size=size)
-        print(search_after)
         if search_after and search_after != '':
-            print(search_after)
             s = s.extra(search_after=search_after.split(','))
+        else:
+            s = s.extra(**{ "from": from_ })
 
     q = Q()
 

--- a/api/es_wrapper.py
+++ b/api/es_wrapper.py
@@ -3,13 +3,16 @@ from services.bitshares_elasticsearch_client import es
 from elasticsearch.exceptions import NotFoundError
 from datetime import datetime, timedelta
 
-def get_account_history(account_id=None, operation_type=None, from_=0, size=10, 
-                        from_date='2015-10-10', to_date='now', sort_by='-block_data.block_time',
-                        type='data', agg_field='operation_type'):
-    if type != "data":
-        s = Search(using=es, index="bitshares-*")
-    else:
-        s = Search(using=es, index="bitshares-*", extra={"size": size, "from": from_})
+def get_account_history(account_id=None, operation_type=None, size=10, 
+                        from_date='2015-10-10', to_date='now', sort_by='-operation_id_num',
+                        search_after=None, type='data', agg_field='operation_type'):
+    s = Search(using=es, index="bitshares-*")
+    if type == "data":
+        s = s.extra(size=size)
+        print(search_after)
+        if search_after and search_after != '':
+            print(search_after)
+            s = s.extra(search_after=search_after.split(','))
 
     q = Q()
 
@@ -24,7 +27,7 @@ def get_account_history(account_id=None, operation_type=None, from_=0, size=10,
     if type != "data":
         s.aggs.bucket('per_field', 'terms', field=agg_field, size=size)
 
-    s = s.sort(sort_by)
+    s = s.sort(*sort_by.split(','))
     response = s.execute()
 
     if type == "data":

--- a/api/explorer.py
+++ b/api/explorer.py
@@ -588,10 +588,11 @@ def get_last_block_number():
     return dynamic_global_properties["head_block_number"]
 
 
-def get_account_history(account_id, search_after):
+def get_account_history(account_id, page, search_after):
     account_id = _get_account_id(account_id)
 
-    operations = es_wrapper.get_account_history(account_id=account_id, search_after=search_after, size=20, sort_by='-account_history.id.keyword')
+    from_ = page * 20
+    operations = es_wrapper.get_account_history(account_id=account_id, from_=from_, search_after=search_after, size=20, sort_by='-account_history.operation_id.keyword')
 
     results = []
     for op in operations:

--- a/api/explorer.py
+++ b/api/explorer.py
@@ -588,11 +588,10 @@ def get_last_block_number():
     return dynamic_global_properties["head_block_number"]
 
 
-def get_account_history(account_id, page):
+def get_account_history(account_id, search_after):
     account_id = _get_account_id(account_id)
 
-    from_ = int(page) * 20
-    operations = es_wrapper.get_account_history(account_id=account_id, from_=from_, size=20, sort_by='-block_data.block_time')
+    operations = es_wrapper.get_account_history(account_id=account_id, search_after=search_after, size=20, sort_by='-account_history.id.keyword')
 
     results = []
     for op in operations:

--- a/swagger/paths_es_wrapper.yaml
+++ b/swagger/paths_es_wrapper.yaml
@@ -17,11 +17,17 @@ paths:
           default: -1
           description: 1-44 Operation type
         - in: query
+          name: from_
+          default: 0
+          type: integer
+          required: false
+          description: Record to start getting results. If more than 10000 results, use search_after instead.
+        - in: query
           name: search_after
           default: ''
           type: string
           required: false
-          description: Start search after this value, should match sort_by type. Multiple fields could be provided separated by a coma.
+          description: Start search after this value, should match sort_by type. Multiple fields could be provided separated by a coma. This will take precedence of the from_ paremeter.
         - in: query
           name: size
           default: 10

--- a/swagger/paths_es_wrapper.yaml
+++ b/swagger/paths_es_wrapper.yaml
@@ -17,11 +17,11 @@ paths:
           default: -1
           description: 1-44 Operation type
         - in: query
-          name: from_
-          default: 0
-          type: integer
+          name: search_after
+          default: ''
+          type: string
           required: false
-          description: Record to start getting results
+          description: Start search after this value, should match sort_by type. Multiple fields could be provided separated by a coma.
         - in: query
           name: size
           default: 10
@@ -42,10 +42,10 @@ paths:
           description: End date range
         - in: query
           name: sort_by
-          default: "-block_data.block_time"
+          default: "-operation_id_num"
           type: string
           required: false
-          description: Order by an output field
+          description: Order by an output field, multiple fields could be provided separated by a coma
         - in: query
           name: type
           default: "data"

--- a/swagger/paths_explorer.yaml
+++ b/swagger/paths_explorer.yaml
@@ -136,11 +136,11 @@ paths:
           required: true
           description: the account to get operations from
         - in: query
-          name: page
-          default: 0
-          type: integer
-          required: true
-          description: the page
+          name: search_after
+          default: ''
+          type: string
+          required: false
+          description: the operation id to search the result from
       responses:
         '200':
           description: operations of account by page

--- a/swagger/paths_explorer.yaml
+++ b/swagger/paths_explorer.yaml
@@ -136,11 +136,17 @@ paths:
           required: true
           description: the account to get operations from
         - in: query
+          name: page
+          default: 0
+          type: integer
+          required: false
+          description: the page. Fails if more than 10000 results, use search_after instead.
+        - in: query
           name: search_after
           default: ''
           type: string
           required: false
-          description: the operation id to search the result from
+          description: the operation id to search the result from. This will takes precedence over the page parameter if provided.
       responses:
         '200':
           description: operations of account by page

--- a/tests/test_api_explorer.tavern.yaml
+++ b/tests/test_api_explorer.tavern.yaml
@@ -174,7 +174,7 @@ stages:
       method: GET
       params:
         account_id: 1.2.0
-        search_after: 1.11.0
+        page: 0
     response:
       status_code: 200
       body:

--- a/tests/test_api_explorer.tavern.yaml
+++ b/tests/test_api_explorer.tavern.yaml
@@ -174,7 +174,7 @@ stages:
       method: GET
       params:
         account_id: 1.2.0
-        page: 0
+        search_after: 1.11.0
     response:
       status_code: 200
       body:


### PR DESCRIPTION
Fix #39 

Two backward compatible APIs changes:

  - `/es/account_history`: additional `search_after` parameter that takes a value that match the value of the last element `sort_by` field.
  - `/account_history`: additional `search_after` that accept the operation id (in the form 1.11.x) of the last element retrieved.

Any use of old `from_` or `page` parameter should migrate to `search_after` form to avoid 10000 limit.