### PR TITLE
Optimizations for api_explorer_get_top_proxies (#51)

### DIFF
--- a/swagger/paths_explorer.yaml
+++ b/swagger/paths_explorer.yaml
@@ -462,9 +462,35 @@ paths:
     get:
       description: Get the top proxies
       operationId: api.explorer.get_top_proxies
+      parameters:
+        - in: query
+          name: start
+          default: 0
+          type: integer
+          required: false
+          description: Pagination start
+        - in: query
+          name: limit
+          default: 10
+          type: integer
+          required: false
+          description: Number of records to retreive
       responses:
         '200':
           description: Top X proxies
+        '500':
+          description: Error processing parameters
+      tags:
+        - api
+        - proxy
+        - governance
+  "/proxy_count":
+    get:
+      description: Get the number of proxies
+      operationId: api.explorer.get_proxy_count
+      responses:
+        '200':
+          description: Number of proxies
         '500':
           description: Error processing parameters
       tags:

--- a/tests/test_api_explorer.tavern.yaml
+++ b/tests/test_api_explorer.tavern.yaml
@@ -523,6 +523,20 @@ stages:
               followers: !anyint
               bts_weight_percentage: !anyfloat
 ---
+test_name: Retrieve /proxy_count
+stages:
+  - name: Make sure we have the right content
+    request:
+      url: "{host}/proxy_count"
+      method: GET
+    response:
+      status_code: 200
+      body:
+        $ext:
+          function: tests.util:validate_unique_value
+          extra_kwargs:
+            unique_value: !anyint
+---
 test_name: Retrieve /top_holders
 stages:
   - name: Make sure we have the right content


### PR DESCRIPTION
 - add `start` and `limit` parameters to `/top_proxy`
 - add `/proxy_count`
 - parallelize ES accounts retrieval