### PR TITLE
Add api limiter

### DIFF
--- a/api/explorer.py
+++ b/api/explorer.py
@@ -7,6 +7,8 @@ from services.bitshares_elasticsearch_client import client as bitshares_es_clien
 from services.cache import cache
 import es_wrapper
 import config
+from app import limiter
+
 
 def _bad_request(detail):
     return connexion.problem(400, 'Bad Request', detail)
@@ -177,6 +179,7 @@ def get_block(block_num):
     return block
 
 
+@limiter.limit("1000 per day")
 def get_ticker(base, quote):
     return bitshares_ws_client.request('database', 'get_ticker', [base, quote])
 
@@ -298,6 +301,8 @@ def _ensure_safe_limit(limit):
         limit = 50
     return limit
 
+
+@limiter.limit("1000 per day")
 def get_order_book(base, quote, limit=False):
     limit = _ensure_safe_limit(limit)    
     order_book = bitshares_ws_client.request('database', 'get_order_book', [base, quote, limit])

--- a/app.py
+++ b/app.py
@@ -13,6 +13,9 @@ CORS(app.app)
 from services.cache import cache
 cache.init_app(app.app)
 
+import services.limiter
+limiter = services.limiter.init(app.app)
+
 import config
 from specsynthase.specbuilder import SpecBuilder
 import glob

--- a/requirements/production.pip
+++ b/requirements/production.pip
@@ -2,6 +2,7 @@ flask
 flask-cors
 Flask-Caching
 flask_profiler
+Flask-Limiter
 connexion>=2.0.0
 connexion[swagger-ui]
 websocket-client

--- a/services/limiter.py
+++ b/services/limiter.py
@@ -1,0 +1,12 @@
+from flask_limiter import Limiter
+from flask_limiter.util import get_remote_address
+
+
+def init(app):
+
+    limiter = Limiter(
+        app,
+        key_func=get_remote_address,
+        default_limits=[]
+    )
+    return limiter


### PR DESCRIPTION
![profiler](https://user-images.githubusercontent.com/21685097/68125931-72511280-fef1-11e9-8390-a6883785f62c.png)

This is just minutes after the application starts. It is having too much connections to ticker and order books causing server performance issues.

This PR introduce flask limiter into the api and limit the 2 API calls with 1000 queries per day per IP address.