### PR TITLE
change api node

### DIFF
--- a/config.py
+++ b/config.py
@@ -1,7 +1,9 @@
 import os
 
 
-WEBSOCKET_URL = os.environ.get('WEBSOCKET_URL', "wss://api.bitshares-kibana.info/ws")
+#WEBSOCKET_URL = os.environ.get('WEBSOCKET_URL', "wss://api.bitshares-kibana.info/ws")
+WEBSOCKET_URL = os.environ.get('WEBSOCKET_URL', "wss://eu.nodes.bitshares.ws")
+
 
 
 # Default connection to Elastic Search.


### PR DESCRIPTION
As my server ES is temporally down by lack of space and i was using the same as an API node this PR will change the endpoint to infrastructure.