### PR TITLE
Fixes get_markets and get_daily_volume

### DIFF
--- a/services/bitshares_elasticsearch_client.py
+++ b/services/bitshares_elasticsearch_client.py
@@ -28,7 +28,7 @@ class BitsharesElasticSearchClient():
             "query": {
                 "bool": {
                     "filter": [
-                        { "term": { "operation_type": 4 } }, # NOTE: may logically return duplicate data since not filtering by `is_maker == true`
+                        { "term": { "operation_type": 4 } }, # NOTE: two fill_order_operation entries for each match, one for each side
                         { 
                             "range": { 
                                 "block_data.block_time": { 

--- a/services/bitshares_elasticsearch_client.py
+++ b/services/bitshares_elasticsearch_client.py
@@ -28,7 +28,7 @@ class BitsharesElasticSearchClient():
             "query": {
                 "bool": {
                     "filter": [
-                        { "term": { "operation_type": 4 } },
+                        { "term": { "operation_type": 4 } }, # NOTE: may logically return duplicate data since not filtering by `is_maker == true`
                         { 
                             "range": { 
                                 "block_data.block_time": { 
@@ -51,6 +51,8 @@ class BitsharesElasticSearchClient():
                     },
                     "aggs": {
                         "volume": { "sum" : { "field" : "operation_history.op_object.receives.amount" } }
+                        # NOTE: perhaps better return both `pays.amount` and `receives.amount` (in different fields but not add them together),
+                        #       because it does not make much sense to return only `receives.amount` when filtering by `pays.asset_id`.
                     }
                 }
             }


### PR DESCRIPTION
Get volume data from more reasonable fields.

By the way, since `get_markets` API is used by `get_most_active_markets` and volume of different assets gets added up, there might still be issues.